### PR TITLE
feat: add Profile CID History and Marketplace Explorer pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,6 +339,28 @@
                     </p>
                     <a href="rpcQueryView.html" class="tool-link">Open Tool</a>
                 </div>
+
+                <div class="tool-card">
+                    <div class="tool-icon">
+                        <i class="fas fa-clock-rotate-left"></i>
+                    </div>
+                    <h3 class="tool-title">Profile CID History</h3>
+                    <p class="tool-desc">
+                        Explore how a profile's IPFS CID changed over time
+                    </p>
+                    <a href="profileHistory.html" class="tool-link">Open Tool</a>
+                </div>
+
+                <div class="tool-card">
+                    <div class="tool-icon">
+                        <i class="fas fa-store"></i>
+                    </div>
+                    <h3 class="tool-title">Marketplace Explorer</h3>
+                    <p class="tool-desc">
+                        Browse marketplace catalog, sellers, and inventory
+                    </p>
+                    <a href="marketplaceExplorer.html" class="tool-link">Open Tool</a>
+                </div>
             </div>
         </div>
     </body>

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -681,9 +681,13 @@
             if (currency) priceStr += ' ' + currency;
             card.appendChild(el('div', {className: 'price'}, priceStr));
 
+            var sku = p.sku || item.sku || '';
+            if (sku) {
+                card.appendChild(el('div', {className: 'meta', style: 'font-family:monospace;font-size:0.8rem;'}, 'SKU: ' + sku));
+            }
+
             // Bottom meta section — consistent link style
             var sellerAddr = item.seller || p.seller || '';
-            var sku = p.sku || item.sku || '';
             var metaBottom = el('div', {style: 'margin-top:auto;padding-top:8px;border-top:1px solid var(--border);font-size:0.82rem;color:var(--text-muted);display:flex;flex-direction:column;gap:3px;'});
 
             if (sellerAddr) {
@@ -708,28 +712,22 @@
                     });
                 })(sellerLine, sellerLink, sellerAddr);
             }
-            if (sku) {
-                var skuLine = el('div', {style: 'display:flex;align-items:center;gap:6px;font-size:0.8rem;'});
-                skuLine.appendChild(el('span', {style: 'font-family:monospace;'}, sku));
-                // Availability badge (silent — shows only if feed works)
-                var availUrl = offer.availabilityFeed || null;
-                if (availUrl) {
-                    var badge = el('span', {style: 'margin-left:auto;'});
-                    skuLine.appendChild(badge);
-                    (function(b, url) {
-                        fetch(url).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
-                            if (!data) return;
-                            var qty = data.available != null ? data.available : (data.quantity != null ? data.quantity : (data.inStock != null ? data.inStock : null));
-                            if (qty === true || (typeof qty === 'number' && qty > 0)) {
-                                b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;background:#dcfce7;color:#166534;'},
-                                    typeof qty === 'number' ? qty + ' avail' : 'In stock'));
-                            } else if (qty === false || qty === 0) {
-                                b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;background:#fee2e2;color:#991b1b;'}, 'Out of stock'));
-                            }
-                        }).catch(function() {});
-                    })(badge, availUrl);
-                }
-                metaBottom.appendChild(skuLine);
+            // Inventory badge — construct URL from seller + SKU
+            if (sku && sellerAddr) {
+                var invBadge = el('div', {style: 'font-size:0.8rem;'});
+                metaBottom.appendChild(invBadge);
+                (function(b, s, k) {
+                    var invUrl = apiBase + '/inventory/inventory/100/' + s + '/' + encodeURIComponent(k);
+                    fetch(invUrl).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
+                        if (!data) return;
+                        var qty = data.value != null ? data.value : (data.quantity != null ? data.quantity : null);
+                        if (typeof qty === 'number') {
+                            var color = qty > 0 ? 'background:#dcfce7;color:#166534;' : 'background:#fee2e2;color:#991b1b;';
+                            b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;' + color},
+                                qty > 0 ? qty + ' in stock' : 'Out of stock'));
+                        }
+                    }).catch(function() {});
+                })(invBadge, sellerAddr, sku);
             }
             card.appendChild(metaBottom);
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -905,10 +905,15 @@
     // Seller info cache: { address: { name, type, hasCidHistory } }
     var sellerInfoCache = {};
 
-    async function enrichSeller(address) {
+    // Cache stores promises to deduplicate in-flight requests
+    function enrichSeller(address) {
         var key = address.toLowerCase();
         if (sellerInfoCache[key]) return sellerInfoCache[key];
+        sellerInfoCache[key] = _enrichSellerImpl(key);
+        return sellerInfoCache[key];
+    }
 
+    async function _enrichSellerImpl(key) {
         var info = { name: null, type: null };
 
         // Profile name + CID from pinning service
@@ -970,7 +975,6 @@
         } catch (e) {}
 
 
-        sellerInfoCache[key] = info;
         return info;
     }
 
@@ -1025,7 +1029,7 @@
     function formatCrc(amountWei) {
         if (!amountWei) return '0';
         var s = String(amountWei);
-        if (s.length <= 18) return '0.' + '0'.repeat(18 - s.length) + s.replace(/0+$/, '') || '0';
+        if (s.length <= 18) { var f = s.replace(/0+$/, ''); return f ? '0.' + '0'.repeat(18 - s.length) + f : '0'; }
         var whole = s.slice(0, s.length - 18);
         var frac = s.slice(s.length - 18).replace(/0+$/, '');
         return frac ? whole + '.' + frac : whole;
@@ -1071,6 +1075,7 @@
         paymentFilterSeller = addr;
         paymentFilterGateway = null;
         paymentsLoaded = false;
+        paymentsPage = 0;
         switchTab('payments');
         loadPayments();
     }
@@ -1079,6 +1084,7 @@
         paymentFilterSeller = null;
         paymentFilterGateway = null;
         paymentsLoaded = false;
+        paymentsPage = 0;
         loadPayments();
         syncUrlState();
     }

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -349,8 +349,8 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
-                <option value="https://market-api.staging.aboutcircles.com">Staging</option>
                 <option value="https://market-api.aboutcircles.com/market">Production</option>
+                <option value="https://market-api.staging.aboutcircles.com">Staging</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>
@@ -376,7 +376,7 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    var DEFAULT_API = 'https://market-api.staging.aboutcircles.com';
+    var DEFAULT_API = 'https://market-api.aboutcircles.com/market';
     var PROFILES_API = 'https://rpc.aboutcircles.com/profiles';
     var OPERATOR = '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b';
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -709,7 +709,27 @@
                 })(sellerLine, sellerLink, sellerAddr);
             }
             if (sku) {
-                metaBottom.appendChild(el('div', {style: 'font-family:monospace;font-size:0.8rem;'}, sku));
+                var skuLine = el('div', {style: 'display:flex;align-items:center;gap:6px;font-size:0.8rem;'});
+                skuLine.appendChild(el('span', {style: 'font-family:monospace;'}, sku));
+                // Availability badge (silent — shows only if feed works)
+                var availUrl = offer.availabilityFeed || null;
+                if (availUrl) {
+                    var badge = el('span', {style: 'margin-left:auto;'});
+                    skuLine.appendChild(badge);
+                    (function(b, url) {
+                        fetch(url).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
+                            if (!data) return;
+                            var qty = data.available != null ? data.available : (data.quantity != null ? data.quantity : (data.inStock != null ? data.inStock : null));
+                            if (qty === true || (typeof qty === 'number' && qty > 0)) {
+                                b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;background:#dcfce7;color:#166534;'},
+                                    typeof qty === 'number' ? qty + ' avail' : 'In stock'));
+                            } else if (qty === false || qty === 0) {
+                                b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;background:#fee2e2;color:#991b1b;'}, 'Out of stock'));
+                            }
+                        }).catch(function() {});
+                    })(badge, availUrl);
+                }
+                metaBottom.appendChild(skuLine);
             }
             card.appendChild(metaBottom);
 
@@ -747,11 +767,14 @@
             var chain = seller.chainId || '100';
             var card = el('div', {className: 'product-card', id: 'seller-' + addr.toLowerCase()});
 
-            // Header: name + type badge (async)
-            var nameRow = el('div', {style: 'display:flex;align-items:center;gap:8px;margin-bottom:4px;'});
+            // Header: avatar + name + type badge
+            var headerRow = el('div', {style: 'display:flex;align-items:center;gap:10px;margin-bottom:4px;'});
+            var avatarImg = el('img', {style: 'width:36px;height:36px;border-radius:50%;object-fit:cover;background:var(--border);display:none;'});
+            avatarImg.id = 'seller-avatar-' + addr.toLowerCase();
+            headerRow.appendChild(avatarImg);
             var nameEl = el('h3', {style: 'margin:0;'}, 'Loading...');
-            nameRow.appendChild(nameEl);
-            card.appendChild(nameRow);
+            headerRow.appendChild(nameEl);
+            card.appendChild(headerRow);
 
             // Address row
             var addrRow = el('div', {className: 'meta', style: 'font-family:monospace;display:flex;align-items:center;gap:4px;'});
@@ -793,7 +816,7 @@
 
             card.appendChild(actions);
 
-            // Async enrich name + type
+            // Async enrich name + type + avatar
             (function(ne, addr) {
                 enrichSeller(addr).then(function(info) {
                     ne.textContent = info.name || truncAddr(addr);
@@ -806,6 +829,11 @@
                                  'background:#f3f4f6;color:#374151;')
                         }, info.type);
                         ne.appendChild(badge);
+                    }
+                    // Show avatar if available
+                    if (info.imageUrl) {
+                        var av = document.getElementById('seller-avatar-' + addr.toLowerCase());
+                        if (av) { av.src = info.imageUrl; av.style.display = ''; }
                     }
                 });
             })(nameEl, addr);
@@ -885,17 +913,32 @@
 
         var info = { name: null, type: null };
 
-        // Profile name from pinning service
+        // Profile name + CID from pinning service
+        var profileCid = null;
         try {
             var res = await fetch(PROFILES_API + '/search?address=' + key);
             if (res.ok) {
                 var data = await res.json();
                 if (Array.isArray(data)) {
                     var profile = data.find(function(p) { return p.address && p.address.toLowerCase() === key; });
-                    if (profile) info.name = profile.name || null;
+                    if (profile) {
+                        info.name = profile.name || null;
+                        profileCid = profile.CID || null;
+                    }
                 }
             }
         } catch (e) {}
+
+        // Fetch CID content for profile image (non-blocking for cache)
+        if (profileCid) {
+            try {
+                var cidRes = await fetch(PROFILES_API + '/get?cid=' + profileCid);
+                if (cidRes.ok) {
+                    var cidData = await cidRes.json();
+                    info.imageUrl = cidData.previewImageUrl || cidData.imageUrl || null;
+                }
+            } catch (e) {}
+        }
 
         // On-chain type from Circles RPC (structured DTO, not raw SQL)
         try {

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -349,8 +349,8 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
-                <option value="https://rpc.aboutcircles.com/market">Production</option>
-                <option value="https://staging.aboutcircles.com/market">Staging</option>
+                <option value="https://market.staging.aboutcircles.com">Staging</option>
+                <option value="https://market-api.aboutcircles.com/market">Production</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>
@@ -376,7 +376,7 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    var DEFAULT_API = 'https://rpc.aboutcircles.com/market';
+    var DEFAULT_API = 'https://market.staging.aboutcircles.com';
     var PROFILES_API = 'https://rpc.aboutcircles.com/profiles';
     var OPERATOR = '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b';
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -1509,7 +1509,6 @@
         if (urlGateway) paymentFilterGateway = urlGateway;
 
         buildTabs();
-        renderInventoryForm();
         loadSellersAndCatalog();
 
         if (urlTab && urlTab !== 'catalog') {

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -674,6 +674,27 @@
             if (sku) {
                 metaBottom.appendChild(el('div', {style: 'font-family:monospace;font-size:0.8rem;'}, sku));
             }
+            // Availability badge — lazy fetch from feed URL if available
+            var availFeed = offer.availabilityFeed || null;
+            if (availFeed) {
+                var availBadge = el('div', {style: 'margin-top:4px;'});
+                availBadge.appendChild(el('span', {style: 'font-size:0.75rem;color:var(--text-muted);'}, 'checking stock...'));
+                metaBottom.appendChild(availBadge);
+                (function(badge, url) {
+                    fetch(url).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
+                        badge.textContent = '';
+                        if (!data) return;
+                        var avail = typeof data === 'object' ? (data.available || data.inStock || data.quantity) : data;
+                        if (avail === true || avail > 0) {
+                            badge.appendChild(el('span', {style: 'font-size:0.75rem;padding:2px 6px;border-radius:8px;background:#dcfce7;color:#166534;'}, 'In stock'));
+                        } else if (avail === false || avail === 0) {
+                            badge.appendChild(el('span', {style: 'font-size:0.75rem;padding:2px 6px;border-radius:8px;background:#fee2e2;color:#991b1b;'}, 'Out of stock'));
+                        } else {
+                            badge.appendChild(el('span', {style: 'font-size:0.75rem;color:var(--text-muted);'}, 'Stock: ' + JSON.stringify(data)));
+                        }
+                    }).catch(function() { badge.textContent = ''; });
+                })(availBadge, availFeed);
+            }
             card.appendChild(metaBottom);
 
             grid.appendChild(card);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -1178,7 +1178,11 @@
             var payerLink = el('a', {href: 'profileChecker.html?address=' + r[0], target: '_blank',
                 className: 'seller-link'}, truncAddr(r[0]));
             payerCell.appendChild(payerLink);
-            // Enrich payer name
+            payerCell.appendChild(document.createTextNode(' '));
+            var payerScan = el('a', {href: 'https://gnosisscan.io/address/' + r[0], target: '_blank',
+                title: 'Gnosisscan', style: 'color:var(--text-muted);font-size:0.75rem;'});
+            payerScan.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square'}));
+            payerCell.appendChild(payerScan);
             (function(link, addr) {
                 enrichSeller(addr).then(function(info) { if (info.name) link.textContent = info.name; });
             })(payerLink, r[0]);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -393,6 +393,11 @@
     var orderPage = 1;
 
     // ─── Init ────────────────────────────────────────────────────────
+    // Re-init on bfcache restore (Brave/Safari back-forward cache)
+    window.addEventListener('pageshow', function(e) {
+        if (e.persisted && !catalogItems.length) loadSellersAndCatalog();
+    });
+
     (function init() {
         var params = new URLSearchParams(window.location.search);
         var override = params.get('marketplaceApi') || params.get('api');
@@ -599,6 +604,21 @@
                 }, truncAddr(sellerAddr));
                 sellerRow.appendChild(sellerLink);
                 card.appendChild(sellerRow);
+                // Async-enrich seller name + type badge on the card
+                (function(row, link, addr) {
+                    enrichSeller(addr).then(function(info) {
+                        if (info.name) link.textContent = info.name;
+                        if (info.type) {
+                            var badge = el('span', {
+                                style: 'margin-left:4px;font-size:0.7rem;padding:1px 5px;border-radius:8px;' +
+                                    (info.type === 'human' ? 'background:#dcfce7;color:#166534;' :
+                                     info.type === 'organization' ? 'background:#dbeafe;color:#1e40af;' :
+                                     'background:#f3f4f6;color:#374151;')
+                            }, info.type);
+                            row.appendChild(badge);
+                        }
+                    });
+                })(sellerRow, sellerLink, sellerAddr);
             }
 
             var sku = p.sku || item.sku || '';
@@ -646,6 +666,7 @@
             var chain = seller.chainId || '100';
             var row = el('tr');
 
+            // Address
             var addrCell = el('td', {className: 'address-cell'});
             addrCell.appendChild(document.createTextNode(truncAddr(addr) + ' '));
             var cpBtn = el('button', {className: 'copy-btn', title: 'Copy address',
@@ -654,25 +675,44 @@
             addrCell.appendChild(cpBtn);
             row.appendChild(addrCell);
 
+            // Chain
             row.appendChild(el('td', {}, String(chain)));
 
-            var nameCell = el('td', {}, 'Loading...');
-            row.appendChild(nameCell);
-            enrichProfileName(addr).then(function(name) {
-                nameCell.textContent = name;
-            });
+            // Profile + type (async enriched)
+            var infoCell = el('td', {}, 'Loading...');
+            row.appendChild(infoCell);
 
+            // Actions (async — links depend on enrichment)
             var actCell = el('td');
-            var profileBtn = el('a', {
-                className: 'btn btn-sm btn-outline',
-                href: 'profileChecker.html?address=' + addr,
-                target: '_blank',
-                style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
-            });
-            profileBtn.appendChild(el('i', {className: 'fas fa-user'}));
-            profileBtn.appendChild(document.createTextNode(' Profile'));
-            actCell.appendChild(profileBtn);
             row.appendChild(actCell);
+
+            enrichSeller(addr).then(function(info) {
+                infoCell.textContent = '';
+                renderSellerInfo(infoCell, info, addr);
+
+                // Actions: always show on-chain link, conditionally show CID history
+                var onChainBtn = el('a', {
+                    className: 'btn btn-sm btn-outline',
+                    href: 'profileChecker.html?address=' + addr,
+                    target: '_blank',
+                    style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;margin-right:6px;'
+                });
+                onChainBtn.appendChild(el('i', {className: 'fas fa-link'}));
+                onChainBtn.appendChild(document.createTextNode(' On-chain'));
+                actCell.appendChild(onChainBtn);
+
+                if (info.hasCidHistory) {
+                    var cidBtn = el('a', {
+                        className: 'btn btn-sm btn-outline',
+                        href: 'profileHistory.html?address=' + addr,
+                        target: '_blank',
+                        style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
+                    });
+                    cidBtn.appendChild(el('i', {className: 'fas fa-clock-rotate-left'}));
+                    cidBtn.appendChild(document.createTextNode(' CID History'));
+                    actCell.appendChild(cidBtn);
+                }
+            });
 
             tbody.appendChild(row);
         });
@@ -681,18 +721,72 @@
         container.appendChild(table);
     }
 
-    async function enrichProfileName(address) {
+    // Seller info cache: { address: { name, type, hasCidHistory } }
+    var sellerInfoCache = {};
+
+    async function enrichSeller(address) {
+        var key = address.toLowerCase();
+        if (sellerInfoCache[key]) return sellerInfoCache[key];
+
+        var info = { name: null, type: null, hasCidHistory: false };
+
+        // Profile name from pinning service
         try {
-            var res = await fetch(PROFILES_API + '/search?address=' + address.toLowerCase());
-            if (!res.ok) return 'Unknown';
-            var data = await res.json();
-            if (Array.isArray(data)) {
-                var profile = data.find(function(p) { return p.address && p.address.toLowerCase() === address.toLowerCase(); });
-                return profile ? (profile.name || 'No name') : 'Not found';
+            var res = await fetch(PROFILES_API + '/search?address=' + key);
+            if (res.ok) {
+                var data = await res.json();
+                if (Array.isArray(data)) {
+                    var profile = data.find(function(p) { return p.address && p.address.toLowerCase() === key; });
+                    if (profile) info.name = profile.name || null;
+                }
             }
-            return 'Unknown';
-        } catch (e) {
-            return 'Error';
+        } catch (e) {}
+
+        // On-chain type from Circles RPC
+        try {
+            var rpcRes = await fetch('https://rpc.aboutcircles.com', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({jsonrpc:'2.0',id:1,method:'circles_query',params:[
+                    'select avatar, avatar_type from v_avatars where avatar = \'' + key + '\' limit 1'
+                ]})
+            });
+            if (rpcRes.ok) {
+                var rpcData = await rpcRes.json();
+                var rows = rpcData.result && rpcData.result.rows;
+                if (rows && rows.length) info.type = rows[0][1] || null; // avatar_type
+            }
+        } catch (e) {}
+
+        // CID history availability (quick check)
+        try {
+            var histRes = await fetch(PROFILES_API + '/avatar/' + key + '/history?limit=1&offset=0');
+            if (histRes.ok) {
+                var histData = await histRes.json();
+                var entries = Array.isArray(histData) ? histData : (histData.history || []);
+                info.hasCidHistory = entries.length > 0;
+            }
+        } catch (e) {}
+
+        sellerInfoCache[key] = info;
+        return info;
+    }
+
+    function renderSellerInfo(container, info, addr) {
+        // Name or address
+        var label = info.name || truncAddr(addr);
+        container.appendChild(document.createTextNode(label));
+
+        // On-chain type badge
+        if (info.type) {
+            var badge = el('span', {
+                style: 'margin-left:6px;font-size:0.75rem;padding:1px 6px;border-radius:8px;' +
+                    (info.type === 'human' ? 'background:#dcfce7;color:#166534;' :
+                     info.type === 'organization' ? 'background:#dbeafe;color:#1e40af;' :
+                     info.type === 'group' ? 'background:#e0e7ff;color:#3730a3;' :
+                     'background:#f3f4f6;color:#374151;')
+            }, info.type);
+            container.appendChild(badge);
         }
     }
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -378,6 +378,10 @@
             <div id="sellersContent"></div>
         </div>
 
+        <div class="tab-content" id="tab-payments">
+            <div id="paymentsContent"></div>
+        </div>
+
         <div class="tab-content" id="tab-orders">
             <div id="ordersContent"></div>
         </div>
@@ -452,6 +456,7 @@
     var TABS = [
         {id: 'catalog', label: 'Catalog', icon: 'fa-boxes-stacked'},
         {id: 'sellers', label: 'Sellers', icon: 'fa-users'},
+        {id: 'payments', label: 'Payments', icon: 'fa-credit-card'},
         {id: 'orders', label: 'Orders', icon: 'fa-receipt', auth: true},
         {id: 'inventory', label: 'Inventory', icon: 'fa-warehouse'}
     ];
@@ -481,6 +486,7 @@
             tc.classList.toggle('active', tc.id === 'tab-' + id);
         });
         if (id === 'orders') renderOrdersTab();
+        if (id === 'payments') loadPayments();
     }
 
     // ─── Catalog + Sellers ───────────────────────────────────────────
@@ -708,6 +714,15 @@
             productsBtn.appendChild(document.createTextNode(' Products'));
             actCell.appendChild(productsBtn);
 
+            var payBtn = el('button', {
+                className: 'btn btn-sm btn-outline',
+                style: 'display:inline-flex;align-items:center;gap:4px;margin-right:6px;',
+                onClick: (function(a) { return function() { filterPaymentsBySeller(a); }; })(addr)
+            });
+            payBtn.appendChild(el('i', {className: 'fas fa-credit-card'}));
+            payBtn.appendChild(document.createTextNode(' Payments'));
+            actCell.appendChild(payBtn);
+
             var scanBtn = el('a', {
                 className: 'btn btn-sm btn-outline',
                 href: 'https://gnosisscan.io/address/' + addr,
@@ -804,6 +819,264 @@
             container.appendChild(badge);
         }
     }
+
+    // ─── Payments tab (on-chain data from indexer) ─────────────────
+    var RPC_URL = 'https://rpc.aboutcircles.com/';
+    var paymentsLoaded = false;
+    var paymentsPage = 0;
+    var paymentsPageSize = 25;
+    var allPayments = [];
+    var allGateways = {};
+    var paymentFilterSeller = null;
+
+    function rpcQuery(namespace, table, columns, filter, limit, order) {
+        var params = {Namespace: namespace, Table: table, Columns: columns, Filter: filter || [], Limit: limit || 50};
+        if (order) params.Order = order;
+        return fetch(RPC_URL, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({jsonrpc:'2.0', id:1, method:'circles_query', params:[params]})
+        }).then(function(r) { return r.json(); }).then(function(d) { return d.result; });
+    }
+
+    function hexToUtf8(hex) {
+        if (!hex || !hex.startsWith('0x')) return hex || '';
+        try {
+            var bytes = [];
+            for (var i = 2; i < hex.length; i += 2)
+                bytes.push(parseInt(hex.substr(i, 2), 16));
+            return new TextDecoder().decode(new Uint8Array(bytes));
+        } catch (e) { return hex; }
+    }
+
+    function formatCrc(amountWei) {
+        if (!amountWei) return '0';
+        var s = String(amountWei);
+        if (s.length <= 18) return '0.' + '0'.repeat(18 - s.length) + s.replace(/0+$/, '') || '0';
+        var whole = s.slice(0, s.length - 18);
+        var frac = s.slice(s.length - 18).replace(/0+$/, '');
+        return frac ? whole + '.' + frac : whole;
+    }
+
+    async function loadPayments() {
+        if (paymentsLoaded && !paymentFilterSeller) return;
+        var container = document.getElementById('paymentsContent');
+        showLoading(container);
+
+        try {
+            // Load gateways if not cached
+            if (!Object.keys(allGateways).length) {
+                var gwResult = await rpcQuery('CrcV2_PaymentGateway', 'GatewayCreated',
+                    ['owner', 'gateway', 'blockNumber', 'timestamp'], [], 200);
+                (gwResult.rows || []).forEach(function(r) {
+                    allGateways[r[1].toLowerCase()] = { owner: r[0], gateway: r[1], block: r[2], created: r[3] };
+                });
+            }
+
+            // Load payments
+            var filter = [];
+            if (paymentFilterSeller) {
+                filter.push({Type:'FilterPredicate', FilterType:'Equals', Column:'payee', Value: paymentFilterSeller.toLowerCase()});
+            }
+            var result = await rpcQuery('CrcV2_PaymentGateway', 'PaymentReceived',
+                ['payer', 'payee', 'gateway', 'amount', 'data', 'timestamp', 'transactionHash', 'blockNumber'],
+                filter, 200,
+                [{Column:'blockNumber', SortOrder:'DESC'}]);
+
+            allPayments = result.rows || [];
+            paymentsLoaded = !paymentFilterSeller;
+            renderPayments();
+        } catch (err) {
+            showError(container, 'Failed to load payments: ' + err.message);
+        }
+    }
+
+    function filterPaymentsBySeller(addr) {
+        paymentFilterSeller = addr;
+        paymentsLoaded = false;
+        switchTab('payments');
+        loadPayments();
+    }
+
+    function clearPaymentFilter() {
+        paymentFilterSeller = null;
+        paymentsLoaded = false;
+        loadPayments();
+    }
+
+    function renderPayments() {
+        var container = clearEl('paymentsContent');
+
+        // Summary stats
+        var totalVolume = 0;
+        var uniquePayers = {};
+        var uniquePayees = {};
+        allPayments.forEach(function(r) {
+            totalVolume += parseFloat(formatCrc(r[3]));
+            uniquePayers[r[0]] = true;
+            uniquePayees[r[1]] = true;
+        });
+
+        var stats = el('div', {style: 'display:flex;gap:16px;margin-bottom:16px;flex-wrap:wrap;'});
+        [['Payments', allPayments.length], ['Volume', totalVolume.toFixed(2) + ' CRC'],
+         ['Unique Payers', Object.keys(uniquePayers).length], ['Unique Payees', Object.keys(uniquePayees).length]
+        ].forEach(function(s) {
+            var card = el('div', {style: 'background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:12px 16px;min-width:120px;'});
+            card.appendChild(el('div', {style: 'font-size:0.8rem;color:var(--text-muted);'}, s[0]));
+            card.appendChild(el('div', {style: 'font-size:1.3rem;font-weight:700;'}, String(s[1])));
+            stats.appendChild(card);
+        });
+        container.appendChild(stats);
+
+        // Filter banner
+        if (paymentFilterSeller) {
+            var banner = el('div', {style: 'display:flex;align-items:center;gap:8px;padding:8px 12px;background:#dbeafe;border-radius:6px;margin-bottom:12px;font-size:0.9rem;'});
+            banner.appendChild(el('i', {className: 'fas fa-filter', style: 'color:#1e40af;'}));
+            var info = sellerInfoCache[paymentFilterSeller.toLowerCase()];
+            var label = info && info.name ? info.name : truncAddr(paymentFilterSeller);
+            banner.appendChild(document.createTextNode('Payments to: ' + label));
+            var clearBtn = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:auto;', onClick: clearPaymentFilter});
+            clearBtn.appendChild(el('i', {className: 'fas fa-xmark', style: 'margin-right:4px;'}));
+            clearBtn.appendChild(document.createTextNode('Clear'));
+            banner.appendChild(clearBtn);
+            container.appendChild(banner);
+        }
+
+        // Gateways summary
+        var gwCount = Object.keys(allGateways).length;
+        if (gwCount && !paymentFilterSeller) {
+            var gwSection = el('div', {style: 'margin-bottom:16px;'});
+            gwSection.appendChild(el('h4', {style: 'margin-bottom:8px;font-size:0.95rem;'}, 'Payment Gateways (' + gwCount + ')'));
+            var gwTable = el('table');
+            var gwTh = el('thead');
+            var gwHr = el('tr');
+            ['Owner', 'Gateway Address', 'Created'].forEach(function(h) { gwHr.appendChild(el('th', {}, h)); });
+            gwTh.appendChild(gwHr);
+            gwTable.appendChild(gwTh);
+            var gwTb = el('tbody');
+            Object.values(allGateways).forEach(function(gw) {
+                var row = el('tr');
+                // Owner — clickable to filter payments
+                var ownerCell = el('td', {className: 'address-cell'});
+                var ownerLink = el('a', {href: '#', className: 'seller-link',
+                    onClick: (function(a) { return function(e) { e.preventDefault(); filterPaymentsBySeller(a); }; })(gw.owner)
+                }, truncAddr(gw.owner));
+                ownerCell.appendChild(ownerLink);
+                // Async enrich owner name
+                (function(link, addr) {
+                    enrichSeller(addr).then(function(info) { if (info.name) link.textContent = info.name; });
+                })(ownerLink, gw.owner);
+                ownerCell.appendChild(document.createTextNode(' '));
+                var cpBtn = el('button', {className: 'copy-btn', title: 'Copy', onClick: function() { copyText(gw.owner); }});
+                cpBtn.appendChild(el('i', {className: 'fas fa-copy'}));
+                ownerCell.appendChild(cpBtn);
+                row.appendChild(ownerCell);
+
+                var gwCell = el('td', {className: 'address-cell'});
+                gwCell.appendChild(document.createTextNode(truncAddr(gw.gateway) + ' '));
+                var gwCp = el('button', {className: 'copy-btn', title: 'Copy', onClick: function() { copyText(gw.gateway); }});
+                gwCp.appendChild(el('i', {className: 'fas fa-copy'}));
+                gwCell.appendChild(gwCp);
+                row.appendChild(gwCell);
+
+                row.appendChild(el('td', {}, new Date(gw.created * 1000).toLocaleString()));
+                gwTb.appendChild(row);
+            });
+            gwTable.appendChild(gwTb);
+            gwSection.appendChild(gwTable);
+            container.appendChild(gwSection);
+        }
+
+        // Payments table
+        if (!allPayments.length) {
+            container.appendChild(el('div', {className: 'empty-state'}, 'No payments found.'));
+            return;
+        }
+
+        container.appendChild(el('h4', {style: 'margin-bottom:8px;font-size:0.95rem;'}, 'Recent Payments'));
+        var table = el('table');
+        var thead = el('thead');
+        var hr = el('tr');
+        ['Time', 'Payer', 'Payee', 'Amount', 'Reference', 'Tx'].forEach(function(h) { hr.appendChild(el('th', {}, h)); });
+        thead.appendChild(hr);
+        table.appendChild(thead);
+
+        var tbody = el('tbody');
+        // Paginate
+        var start = paymentsPage * paymentsPageSize;
+        var page = allPayments.slice(start, start + paymentsPageSize);
+
+        page.forEach(function(r) {
+            var row = el('tr');
+            // Time
+            row.appendChild(el('td', {style: 'white-space:nowrap;font-size:0.85rem;'}, new Date(r[5] * 1000).toLocaleString()));
+
+            // Payer — clickable to filter
+            var payerCell = el('td', {className: 'address-cell'});
+            payerCell.appendChild(el('a', {href: 'https://gnosisscan.io/address/' + r[0], target: '_blank', className: 'seller-link'}, truncAddr(r[0])));
+            row.appendChild(payerCell);
+
+            // Payee — clickable to filter payments
+            var payeeCell = el('td', {className: 'address-cell'});
+            var payeeLink = el('a', {href: '#', className: 'seller-link',
+                onClick: (function(a) { return function(e) { e.preventDefault(); filterPaymentsBySeller(a); }; })(r[1])
+            }, truncAddr(r[1]));
+            payeeCell.appendChild(payeeLink);
+            // Enrich payee name
+            (function(link, addr) {
+                enrichSeller(addr).then(function(info) { if (info.name) link.textContent = info.name; });
+            })(payeeLink, r[1]);
+            row.appendChild(payeeCell);
+
+            // Amount
+            row.appendChild(el('td', {style: 'font-weight:600;color:var(--accent);white-space:nowrap;'}, formatCrc(r[3]) + ' CRC'));
+
+            // Reference (decoded from hex)
+            var ref = hexToUtf8(r[4]);
+            var refCell = el('td', {style: 'font-family:monospace;font-size:0.8rem;'});
+            refCell.appendChild(document.createTextNode(ref.length > 20 ? ref.slice(0, 20) + '...' : ref));
+            var refCp = el('button', {className: 'copy-btn', title: 'Copy reference', onClick: (function(t) { return function() { copyText(t); }; })(ref)});
+            refCp.appendChild(el('i', {className: 'fas fa-copy'}));
+            refCell.appendChild(refCp);
+            row.appendChild(refCell);
+
+            // Tx link
+            var txCell = el('td');
+            txCell.appendChild(el('a', {
+                href: 'https://gnosisscan.io/tx/' + r[6],
+                target: '_blank',
+                className: 'seller-link',
+                style: 'font-size:0.8rem;'
+            }, truncAddr(r[6])));
+            row.appendChild(txCell);
+
+            tbody.appendChild(row);
+        });
+        table.appendChild(tbody);
+        container.appendChild(table);
+
+        // Pagination
+        var totalPages = Math.ceil(allPayments.length / paymentsPageSize);
+        if (totalPages > 1) {
+            var pag = el('div', {className: 'pagination'});
+            pag.appendChild(el('button', {
+                className: 'btn btn-sm btn-outline',
+                disabled: paymentsPage <= 0 ? 'true' : undefined,
+                onClick: function() { paymentsPage--; renderPayments(); }
+            }, 'Prev'));
+            pag.appendChild(el('span', {}, 'Page ' + (paymentsPage + 1) + ' of ' + totalPages));
+            pag.appendChild(el('button', {
+                className: 'btn btn-sm btn-outline',
+                disabled: paymentsPage >= totalPages - 1 ? 'true' : undefined,
+                onClick: function() { paymentsPage++; renderPayments(); }
+            }, 'Next'));
+            container.appendChild(pag);
+        }
+    }
+
+    // ─── Cross-tab navigation helpers ────────────────────────────────
+    // Used by sellers table → payments, catalog → seller filter, etc.
+    function viewSellerPayments(addr) { filterPaymentsBySeller(addr); }
 
     // ─── Inventory ───────────────────────────────────────────────────
     function renderInventoryForm() {

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -1,0 +1,628 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Marketplace Explorer</title>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
+    <style>
+        :root {
+            --primary: #191568;
+            --accent: #ff491b;
+            --bg: #fff7f5;
+            --card-bg: #ffffff;
+            --border: #e5e3fb;
+            --text: #191568;
+            --text-muted: #666;
+            --error: #ef4444;
+        }
+        * { box-sizing: border-box; margin: 0; }
+        body {
+            font-family: "DM Sans", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.5;
+        }
+        header {
+            background: var(--primary);
+            color: #fff;
+            padding: 15px 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 15px;
+            flex-wrap: wrap;
+        }
+        header h1 { margin: 0; font-weight: 600; font-size: 1.3rem; }
+        .header-links a {
+            color: rgba(255,255,255,0.8);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+        .header-links a:hover { color: #fff; }
+        .container {
+            max-width: 1100px;
+            margin: 20px auto;
+            padding: 0 20px;
+        }
+        .api-config {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-bottom: 12px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .api-config code {
+            background: #f0eef9;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.8rem;
+        }
+
+        /* Tabs */
+        .tab-bar {
+            display: flex;
+            border-bottom: 2px solid var(--border);
+            margin-bottom: 20px;
+            gap: 4px;
+            overflow-x: auto;
+        }
+        .tab-btn {
+            padding: 10px 20px;
+            border: none;
+            background: transparent;
+            font-family: inherit;
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: var(--text-muted);
+            cursor: pointer;
+            border-bottom: 2px solid transparent;
+            margin-bottom: -2px;
+            transition: color 0.2s, border-color 0.2s;
+            white-space: nowrap;
+        }
+        .tab-btn:hover { color: var(--text); }
+        .tab-btn.active {
+            color: var(--accent);
+            border-bottom-color: var(--accent);
+            font-weight: 600;
+        }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+
+        /* Buttons */
+        .btn {
+            padding: 10px 20px;
+            background: var(--primary);
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.95rem;
+            font-weight: 600;
+            font-family: inherit;
+            transition: background 0.2s;
+        }
+        .btn:hover { background: #251b9f; }
+        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .btn-sm { padding: 6px 14px; font-size: 0.85rem; border-radius: 4px; }
+        .btn-outline { background: transparent; color: var(--primary); border: 1px solid var(--border); }
+        .btn-outline:hover { background: var(--border); }
+
+        /* Card grid */
+        .card-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+            gap: 16px;
+        }
+        .product-card {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            transition: box-shadow 0.2s;
+        }
+        .product-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
+        .product-card h3 { font-size: 1rem; margin: 0; }
+        .product-card .price {
+            font-weight: 600;
+            color: var(--accent);
+            font-size: 1.1rem;
+        }
+        .product-card .meta {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+        .product-card .seller-link {
+            font-size: 0.85rem;
+            color: var(--primary);
+            text-decoration: none;
+        }
+        .product-card .seller-link:hover { text-decoration: underline; }
+        .product-img {
+            width: 100%;
+            height: 160px;
+            object-fit: cover;
+            border-radius: 6px;
+            background: var(--border);
+        }
+
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.92rem;
+            background: var(--card-bg);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+        th, td {
+            text-align: left;
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+        }
+        th { background: #f0eef9; font-weight: 600; }
+        tr:hover td { background: #fafafa; }
+        .address-cell {
+            font-family: monospace;
+            font-size: 0.85rem;
+        }
+
+        /* Form */
+        .form-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 12px;
+            align-items: flex-end;
+            flex-wrap: wrap;
+        }
+        .form-group { display: flex; flex-direction: column; gap: 4px; }
+        .form-group label { font-weight: 600; font-size: 0.85rem; }
+        .form-group input {
+            padding: 8px 12px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-family: inherit;
+            font-size: 0.9rem;
+        }
+        .form-group input:focus { outline: 2px solid var(--primary); border-color: transparent; }
+
+        /* Pagination */
+        .pagination {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            margin-top: 16px;
+        }
+        .pagination span { font-size: 0.85rem; color: var(--text-muted); }
+
+        /* General */
+        .loader {
+            border: 3px solid #f3f3f3;
+            border-top: 3px solid var(--primary);
+            border-radius: 50%;
+            width: 20px; height: 20px;
+            animation: spin 0.8s linear infinite;
+            display: inline-block;
+            vertical-align: middle;
+        }
+        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+        .error-msg { color: var(--error); padding: 12px; background: #fef2f2; border-radius: 6px; margin: 10px 0; }
+        .empty-state { text-align: center; color: var(--text-muted); padding: 40px 20px; }
+        .copy-btn {
+            background: none; border: none; cursor: pointer;
+            color: var(--text-muted); font-size: 0.85rem; padding: 2px;
+        }
+        .copy-btn:hover { color: var(--primary); }
+
+        @media (max-width: 600px) {
+            .form-row { flex-direction: column; }
+            .card-grid { grid-template-columns: 1fr; }
+        }
+    </style>
+    <script defer data-domain="aboutcircles.github.io/circlestools" src="https://plausible.io/js/script.js"></script>
+</head>
+<body>
+    <header>
+        <div>
+            <h1><i class="fas fa-store" style="margin-right: 8px;"></i>Marketplace Explorer</h1>
+        </div>
+        <div class="header-links">
+            <a href="index.html"><i class="fas fa-home"></i> Tools</a>
+        </div>
+    </header>
+
+    <div class="container">
+        <div class="api-config">
+            <i class="fas fa-server"></i>
+            API: <code id="apiUrlDisplay"></code>
+        </div>
+
+        <div class="tab-bar" id="tabBar"></div>
+
+        <div class="tab-content active" id="tab-catalog">
+            <div id="catalogContent"></div>
+        </div>
+
+        <div class="tab-content" id="tab-sellers">
+            <div id="sellersContent"></div>
+        </div>
+
+        <div class="tab-content" id="tab-inventory">
+            <div id="inventoryContent"></div>
+        </div>
+    </div>
+
+    <script>
+    // ─── Configuration ───────────────────────────────────────────────
+    var DEFAULT_API = 'https://rpc.aboutcircles.com/market';
+    var PROFILES_API = 'https://rpc.aboutcircles.com/profiles';
+    var OPERATOR = '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b';
+
+    var apiBase = DEFAULT_API;
+    var sellersList = [];
+    var catalogCursor = null;
+    var catalogItems = [];
+    var currentTab = 'catalog';
+
+    // ─── Init ────────────────────────────────────────────────────────
+    (function init() {
+        var params = new URLSearchParams(window.location.search);
+        var override = params.get('marketplaceApi') || params.get('api');
+        if (override) apiBase = override.replace(/\/+$/, '');
+        document.getElementById('apiUrlDisplay').textContent = apiBase;
+        buildTabs();
+        loadSellersAndCatalog();
+        renderInventoryForm();
+    })();
+
+    // ─── DOM helper ──────────────────────────────────────────────────
+    function el(tag, attrs, children) {
+        var e = document.createElement(tag);
+        if (attrs) Object.keys(attrs).forEach(function(k) {
+            var v = attrs[k];
+            if (k === 'className') e.className = v;
+            else if (k === 'textContent') e.textContent = v;
+            else if (k.startsWith('on') && typeof v === 'function') e.addEventListener(k.slice(2).toLowerCase(), v);
+            else e.setAttribute(k, v);
+        });
+        if (children !== undefined && children !== null) {
+            if (typeof children === 'string') e.textContent = children;
+            else if (Array.isArray(children)) children.forEach(function(c) { if (c) e.appendChild(c); });
+            else e.appendChild(children);
+        }
+        return e;
+    }
+
+    function truncAddr(a) {
+        if (!a) return '';
+        return a.slice(0, 6) + '...' + a.slice(-4);
+    }
+
+    function copyText(t) { navigator.clipboard.writeText(t); }
+
+    function clearEl(id) { var e = document.getElementById(id); e.textContent = ''; return e; }
+
+    function showLoading(container) {
+        container.textContent = '';
+        container.appendChild(el('div', {style: 'text-align:center;padding:30px;'}, [
+            el('span', {className: 'loader'}),
+            document.createTextNode(' Loading...')
+        ]));
+    }
+
+    function showError(container, msg) {
+        container.textContent = '';
+        container.appendChild(el('div', {className: 'error-msg'}, msg));
+    }
+
+    // ─── Tabs ────────────────────────────────────────────────────────
+    var TABS = [
+        {id: 'catalog', label: 'Catalog', icon: 'fa-boxes-stacked'},
+        {id: 'sellers', label: 'Sellers', icon: 'fa-users'},
+        {id: 'inventory', label: 'Inventory', icon: 'fa-warehouse'}
+    ];
+
+    function buildTabs() {
+        var bar = document.getElementById('tabBar');
+        bar.textContent = '';
+        TABS.forEach(function(t) {
+            var btn = el('button', {
+                className: 'tab-btn' + (currentTab === t.id ? ' active' : ''),
+                'data-tab': t.id,
+                onClick: function() { switchTab(t.id); }
+            });
+            btn.appendChild(el('i', {className: 'fas ' + t.icon, style: 'margin-right:6px;'}));
+            btn.appendChild(document.createTextNode(t.label));
+            bar.appendChild(btn);
+        });
+    }
+
+    function switchTab(id) {
+        currentTab = id;
+        document.querySelectorAll('.tab-btn').forEach(function(btn) {
+            btn.classList.toggle('active', btn.getAttribute('data-tab') === id);
+        });
+        document.querySelectorAll('.tab-content').forEach(function(tc) {
+            tc.classList.toggle('active', tc.id === 'tab-' + id);
+        });
+    }
+
+    // ─── Catalog + Sellers ───────────────────────────────────────────
+    async function loadSellersAndCatalog() {
+        var catalogContainer = document.getElementById('catalogContent');
+        showLoading(catalogContainer);
+
+        try {
+            var res = await fetch(apiBase + '/api/sellers');
+            if (!res.ok) throw new Error('Sellers API: ' + res.status);
+            var data = await res.json();
+            sellersList = data.sellers || data || [];
+
+            renderSellersTable();
+            await loadCatalog(true);
+        } catch (err) {
+            showError(catalogContainer, 'Failed to load: ' + err.message);
+        }
+    }
+
+    async function loadCatalog(reset) {
+        var container = document.getElementById('catalogContent');
+        if (reset) {
+            catalogItems = [];
+            catalogCursor = null;
+        }
+
+        var avatarParams = sellersList.map(function(s) {
+            return 'avatars=' + encodeURIComponent(s.seller || s.address || s);
+        }).join('&');
+
+        var url = apiBase + '/api/operator/' + OPERATOR + '/catalog?' + avatarParams + '&pageSize=20';
+        if (catalogCursor) url += '&cursor=' + encodeURIComponent(catalogCursor);
+
+        if (reset) showLoading(container);
+
+        try {
+            var res = await fetch(url);
+            if (!res.ok) throw new Error('Catalog API: ' + res.status);
+            var data = await res.json();
+
+            var items = data.items || data.products || data || [];
+            catalogCursor = data.cursor || data.nextCursor || null;
+            catalogItems = catalogItems.concat(items);
+
+            renderCatalog();
+        } catch (err) {
+            showError(container, 'Failed to load catalog: ' + err.message);
+        }
+    }
+
+    function renderCatalog() {
+        var container = clearEl('catalogContent');
+
+        if (!catalogItems.length) {
+            container.appendChild(el('div', {className: 'empty-state'}, 'No catalog items found.'));
+            return;
+        }
+
+        var grid = el('div', {className: 'card-grid'});
+
+        catalogItems.forEach(function(item) {
+            var card = el('div', {className: 'product-card'});
+
+            var imgUrl = item.imageUrl || item.image || '';
+            if (imgUrl) {
+                var img = el('img', {className: 'product-img', alt: item.name || 'Product'});
+                img.src = imgUrl;
+                img.onerror = function() { this.style.display = 'none'; };
+                card.appendChild(img);
+            }
+
+            card.appendChild(el('h3', {}, item.name || item.title || 'Unnamed'));
+
+            if (item.description) {
+                var desc = item.description.length > 100 ? item.description.slice(0, 100) + '...' : item.description;
+                card.appendChild(el('p', {className: 'meta'}, desc));
+            }
+
+            var priceStr = item.price != null ? String(item.price) : 'N/A';
+            if (item.currency) priceStr += ' ' + item.currency;
+            card.appendChild(el('div', {className: 'price'}, priceStr));
+
+            var sellerAddr = item.seller || item.sellerAddress || '';
+            if (sellerAddr) {
+                var sellerRow = el('div', {className: 'meta', style: 'margin-top:4px;'});
+                sellerRow.appendChild(document.createTextNode('Seller: '));
+                var sellerLink = el('a', {
+                    className: 'seller-link',
+                    href: 'profileChecker.html?address=' + sellerAddr,
+                    target: '_blank'
+                }, truncAddr(sellerAddr));
+                sellerRow.appendChild(sellerLink);
+                card.appendChild(sellerRow);
+            }
+
+            if (item.sku) {
+                card.appendChild(el('div', {className: 'meta'}, 'SKU: ' + item.sku));
+            }
+
+            grid.appendChild(card);
+        });
+
+        container.appendChild(grid);
+
+        if (catalogCursor) {
+            var pag = el('div', {className: 'pagination'});
+            var moreBtn = el('button', {className: 'btn btn-sm btn-outline',
+                onClick: function() { loadCatalog(false); }});
+            moreBtn.appendChild(el('i', {className: 'fas fa-chevron-down', style: 'margin-right:6px;'}));
+            moreBtn.appendChild(document.createTextNode('Load More'));
+            pag.appendChild(moreBtn);
+            container.appendChild(pag);
+        }
+    }
+
+    // ─── Sellers table ───────────────────────────────────────────────
+    function renderSellersTable() {
+        var container = clearEl('sellersContent');
+
+        if (!sellersList.length) {
+            container.appendChild(el('div', {className: 'empty-state'}, 'No sellers found.'));
+            return;
+        }
+
+        var table = el('table');
+        var thead = el('thead');
+        var hr = el('tr');
+        ['Address', 'Chain', 'Profile', 'Actions'].forEach(function(h) {
+            hr.appendChild(el('th', {}, h));
+        });
+        thead.appendChild(hr);
+        table.appendChild(thead);
+
+        var tbody = el('tbody');
+        sellersList.forEach(function(seller) {
+            var addr = seller.seller || seller.address || String(seller);
+            var chain = seller.chainId || '100';
+            var row = el('tr');
+
+            var addrCell = el('td', {className: 'address-cell'});
+            addrCell.appendChild(document.createTextNode(truncAddr(addr) + ' '));
+            var cpBtn = el('button', {className: 'copy-btn', title: 'Copy address',
+                onClick: function() { copyText(addr); }});
+            cpBtn.appendChild(el('i', {className: 'fas fa-copy'}));
+            addrCell.appendChild(cpBtn);
+            row.appendChild(addrCell);
+
+            row.appendChild(el('td', {}, String(chain)));
+
+            var nameCell = el('td', {}, 'Loading...');
+            row.appendChild(nameCell);
+            enrichProfileName(addr).then(function(name) {
+                nameCell.textContent = name;
+            });
+
+            var actCell = el('td');
+            var profileBtn = el('a', {
+                className: 'btn btn-sm btn-outline',
+                href: 'profileChecker.html?address=' + addr,
+                target: '_blank',
+                style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
+            });
+            profileBtn.appendChild(el('i', {className: 'fas fa-user'}));
+            profileBtn.appendChild(document.createTextNode(' Profile'));
+            actCell.appendChild(profileBtn);
+            row.appendChild(actCell);
+
+            tbody.appendChild(row);
+        });
+
+        table.appendChild(tbody);
+        container.appendChild(table);
+    }
+
+    async function enrichProfileName(address) {
+        try {
+            var res = await fetch(PROFILES_API + '/search?address=' + address.toLowerCase());
+            if (!res.ok) return 'Unknown';
+            var data = await res.json();
+            if (Array.isArray(data)) {
+                var profile = data.find(function(p) { return p.address && p.address.toLowerCase() === address.toLowerCase(); });
+                return profile ? (profile.name || 'No name') : 'Not found';
+            }
+            return 'Unknown';
+        } catch (e) {
+            return 'Error';
+        }
+    }
+
+    // ─── Inventory ───────────────────────────────────────────────────
+    function renderInventoryForm() {
+        var container = clearEl('inventoryContent');
+
+        var form = el('div');
+        var row = el('div', {className: 'form-row'});
+
+        var chainGroup = el('div', {className: 'form-group'});
+        chainGroup.appendChild(el('label', {}, 'Chain ID'));
+        chainGroup.appendChild(el('input', {type: 'text', id: 'invChainId', value: '100', style: 'width:80px;'}));
+        row.appendChild(chainGroup);
+
+        var sellerGroup = el('div', {className: 'form-group', style: 'flex:1;'});
+        sellerGroup.appendChild(el('label', {}, 'Seller Address'));
+        sellerGroup.appendChild(el('input', {type: 'text', id: 'invSeller', placeholder: '0x...'}));
+        row.appendChild(sellerGroup);
+
+        var skuGroup = el('div', {className: 'form-group'});
+        skuGroup.appendChild(el('label', {}, 'SKU'));
+        skuGroup.appendChild(el('input', {type: 'text', id: 'invSku', placeholder: 'Product SKU'}));
+        row.appendChild(skuGroup);
+
+        var btnGroup = el('div', {className: 'form-group'});
+        btnGroup.appendChild(el('label', {}, '\u00A0'));
+        btnGroup.appendChild(el('button', {className: 'btn', onClick: checkInventory}, 'Check'));
+        row.appendChild(btnGroup);
+
+        form.appendChild(row);
+        container.appendChild(form);
+        container.appendChild(el('div', {id: 'inventoryResult'}));
+    }
+
+    async function checkInventory() {
+        var chainId = document.getElementById('invChainId').value.trim() || '100';
+        var seller = document.getElementById('invSeller').value.trim();
+        var sku = document.getElementById('invSku').value.trim();
+
+        if (!seller || !sku) {
+            showError(document.getElementById('inventoryResult'), 'Please enter seller address and SKU.');
+            return;
+        }
+
+        var resultDiv = clearEl('inventoryResult');
+        showLoading(resultDiv);
+
+        try {
+            var [avail, inv] = await Promise.allSettled([
+                fetch(apiBase + '/inventory/availability/' + chainId + '/' + seller + '/' + encodeURIComponent(sku)).then(function(r) { return r.ok ? r.json() : null; }),
+                fetch(apiBase + '/inventory/inventory/' + chainId + '/' + seller + '/' + encodeURIComponent(sku)).then(function(r) { return r.ok ? r.json() : null; })
+            ]);
+
+            resultDiv.textContent = '';
+            var card = el('div', {className: 'product-card', style: 'max-width:400px;'});
+
+            card.appendChild(el('h3', {}, 'Inventory for SKU: ' + sku));
+
+            if (avail.status === 'fulfilled' && avail.value != null) {
+                var availVal = typeof avail.value === 'object' ? JSON.stringify(avail.value) : String(avail.value);
+                card.appendChild(el('div', {}, [
+                    el('strong', {}, 'Availability: '),
+                    document.createTextNode(availVal)
+                ]));
+            }
+            if (inv.status === 'fulfilled' && inv.value != null) {
+                var invVal = typeof inv.value === 'object' ? JSON.stringify(inv.value, null, 2) : String(inv.value);
+                card.appendChild(el('div', {style: 'margin-top:8px;'}, [
+                    el('strong', {}, 'Inventory Details:'),
+                    el('pre', {style: 'margin-top:4px;font-size:0.85rem;white-space:pre-wrap;'}, invVal)
+                ]));
+            }
+            if ((!avail.value && avail.status === 'fulfilled') && (!inv.value && inv.status === 'fulfilled')) {
+                card.appendChild(el('div', {className: 'meta'}, 'No inventory data found for this combination.'));
+            }
+
+            resultDiv.appendChild(card);
+        } catch (err) {
+            showError(resultDiv, 'Inventory check failed: ' + err.message);
+        }
+    }
+    </script>
+</body>
+</html>

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -449,7 +449,7 @@
             if (k === 'className') e.className = v;
             else if (k === 'textContent') e.textContent = v;
             else if (k.startsWith('on') && typeof v === 'function') e.addEventListener(k.slice(2).toLowerCase(), v);
-            else e.setAttribute(k, v);
+            else if (v !== undefined && v !== null) e.setAttribute(k, v);
         });
         if (children !== undefined && children !== null) {
             if (typeof children === 'string') e.textContent = children;
@@ -755,19 +755,28 @@
             }
         } catch (e) {}
 
-        // On-chain type from Circles RPC
+        // On-chain type from Circles RPC (structured DTO, not raw SQL)
         try {
-            var rpcRes = await fetch('https://rpc.aboutcircles.com', {
+            var rpcRes = await fetch('https://rpc.aboutcircles.com/', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({jsonrpc:'2.0',id:1,method:'circles_query',params:[
-                    'select avatar, avatar_type from v_avatars where avatar = \'' + key + '\' limit 1'
-                ]})
+                body: JSON.stringify({jsonrpc:'2.0',id:1,method:'circles_query',params:[{
+                    Namespace: 'V_Crc',
+                    Table: 'Avatars',
+                    Columns: ['avatar', 'type'],
+                    Filter: [{
+                        Type: 'FilterPredicate',
+                        FilterType: 'Equals',
+                        Column: 'avatar',
+                        Value: key
+                    }],
+                    Limit: 1
+                }]})
             });
             if (rpcRes.ok) {
                 var rpcData = await rpcRes.json();
                 var rows = rpcData.result && rpcData.result.rows;
-                if (rows && rows.length) info.type = rows[0][1] || null; // avatar_type
+                if (rows && rows.length) info.type = rows[0][1] || null;
             }
         } catch (e) {}
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -561,7 +561,18 @@
             banner.appendChild(el('i', {className: 'fas fa-filter', style: 'color:#1e40af;'}));
             var info = sellerInfoCache[catalogFilterSeller.toLowerCase()];
             var label = info && info.name ? info.name : truncAddr(catalogFilterSeller);
-            banner.appendChild(document.createTextNode('Filtered by seller: ' + label));
+            banner.appendChild(document.createTextNode('Filtered by seller: ' + label + ' '));
+            // Quick-jump links for this seller
+            var jumpPayments = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:8px;',
+                onClick: (function(a) { return function() { filterPaymentsBySeller(a); }; })(catalogFilterSeller)});
+            jumpPayments.appendChild(el('i', {className: 'fas fa-credit-card', style: 'margin-right:4px;'}));
+            jumpPayments.appendChild(document.createTextNode('Payments'));
+            banner.appendChild(jumpPayments);
+            var jumpScan = el('a', {className: 'btn btn-sm btn-outline', href: 'https://gnosisscan.io/address/' + catalogFilterSeller,
+                target: '_blank', style: 'text-decoration:none;margin-left:4px;'});
+            jumpScan.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square', style: 'margin-right:4px;'}));
+            jumpScan.appendChild(document.createTextNode('Gnosisscan'));
+            banner.appendChild(jumpScan);
             var clearBtn = el('button', {
                 className: 'btn btn-sm btn-outline',
                 style: 'margin-left:auto;',
@@ -934,7 +945,17 @@
             banner.appendChild(el('i', {className: 'fas fa-filter', style: 'color:#1e40af;'}));
             var info = sellerInfoCache[paymentFilterSeller.toLowerCase()];
             var label = info && info.name ? info.name : truncAddr(paymentFilterSeller);
-            banner.appendChild(document.createTextNode('Payments to: ' + label));
+            banner.appendChild(document.createTextNode('Payments to: ' + label + ' '));
+            var jumpProducts = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:8px;',
+                onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(paymentFilterSeller)});
+            jumpProducts.appendChild(el('i', {className: 'fas fa-boxes-stacked', style: 'margin-right:4px;'}));
+            jumpProducts.appendChild(document.createTextNode('Products'));
+            banner.appendChild(jumpProducts);
+            var jumpScan = el('a', {className: 'btn btn-sm btn-outline', href: 'https://gnosisscan.io/address/' + paymentFilterSeller,
+                target: '_blank', style: 'text-decoration:none;margin-left:4px;'});
+            jumpScan.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square', style: 'margin-right:4px;'}));
+            jumpScan.appendChild(document.createTextNode('Gnosisscan'));
+            banner.appendChild(jumpScan);
             var clearBtn = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:auto;', onClick: clearPaymentFilter});
             clearBtn.appendChild(el('i', {className: 'fas fa-xmark', style: 'margin-right:4px;'}));
             clearBtn.appendChild(document.createTextNode('Clear'));

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -558,28 +558,37 @@
         var grid = el('div', {className: 'card-grid'});
 
         catalogItems.forEach(function(item) {
+            // Catalog items use nested schema.org structure: item.product.name, etc.
+            var p = item.product || item;
+            var offer = (p.offers && p.offers[0]) || {};
             var card = el('div', {className: 'product-card'});
 
-            var imgUrl = item.imageUrl || item.image || '';
+            // Image: product.image is an array of URLs
+            var imgUrl = '';
+            if (Array.isArray(p.image) && p.image.length) imgUrl = p.image[0];
+            else if (typeof p.image === 'string') imgUrl = p.image;
+            else imgUrl = p.imageUrl || '';
             if (imgUrl) {
-                var img = el('img', {className: 'product-img', alt: item.name || 'Product'});
+                var img = el('img', {className: 'product-img', alt: p.name || 'Product'});
                 img.src = imgUrl;
                 img.onerror = function() { this.style.display = 'none'; };
                 card.appendChild(img);
             }
 
-            card.appendChild(el('h3', {}, item.name || item.title || 'Unnamed'));
+            card.appendChild(el('h3', {}, p.name || p.title || 'Unnamed'));
 
-            if (item.description) {
-                var desc = item.description.length > 100 ? item.description.slice(0, 100) + '...' : item.description;
+            if (p.description) {
+                var desc = p.description.length > 100 ? p.description.slice(0, 100) + '...' : p.description;
                 card.appendChild(el('p', {className: 'meta'}, desc));
             }
 
-            var priceStr = item.price != null ? String(item.price) : 'N/A';
-            if (item.currency) priceStr += ' ' + item.currency;
+            var price = offer.price != null ? offer.price : p.price;
+            var currency = offer.priceCurrency || p.currency || '';
+            var priceStr = price != null ? String(price) : 'N/A';
+            if (currency) priceStr += ' ' + currency;
             card.appendChild(el('div', {className: 'price'}, priceStr));
 
-            var sellerAddr = item.seller || item.sellerAddress || '';
+            var sellerAddr = item.seller || p.seller || '';
             if (sellerAddr) {
                 var sellerRow = el('div', {className: 'meta', style: 'margin-top:4px;'});
                 sellerRow.appendChild(document.createTextNode('Seller: '));
@@ -592,8 +601,9 @@
                 card.appendChild(sellerRow);
             }
 
-            if (item.sku) {
-                card.appendChild(el('div', {className: 'meta'}, 'SKU: ' + item.sku));
+            var sku = p.sku || item.sku || '';
+            if (sku) {
+                card.appendChild(el('div', {className: 'meta'}, 'SKU: ' + sku));
             }
 
             grid.appendChild(card);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -424,8 +424,10 @@
         });
 
         buildTabs();
-        loadSellersAndCatalog();
         renderInventoryForm();
+        // Delay initial load slightly — Brave Shields can block fetches during
+        // synchronous script execution but allows them after a microtask
+        setTimeout(function() { loadSellersAndCatalog(); }, 0);
     })();
 
     // ─── DOM helper ──────────────────────────────────────────────────

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -1147,16 +1147,19 @@
                 var label = info && info.name ? info.name : truncAddr(paymentFilterSeller);
                 banner.appendChild(document.createTextNode('Payments to: ' + label + ' '));
             }
-            var jumpProducts = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:8px;',
-                onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(paymentFilterSeller)});
-            jumpProducts.appendChild(el('i', {className: 'fas fa-boxes-stacked', style: 'margin-right:4px;'}));
-            jumpProducts.appendChild(document.createTextNode('Products'));
-            banner.appendChild(jumpProducts);
-            var jumpScan = el('a', {className: 'btn btn-sm btn-outline', href: 'https://gnosisscan.io/address/' + paymentFilterSeller,
-                target: '_blank', style: 'text-decoration:none;margin-left:4px;'});
-            jumpScan.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square', style: 'margin-right:4px;'}));
-            jumpScan.appendChild(document.createTextNode('Gnosisscan'));
-            banner.appendChild(jumpScan);
+            // Only show seller-specific links when filtering by seller (not gateway-only)
+            if (paymentFilterSeller) {
+                var jumpProducts = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:8px;',
+                    onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(paymentFilterSeller)});
+                jumpProducts.appendChild(el('i', {className: 'fas fa-boxes-stacked', style: 'margin-right:4px;'}));
+                jumpProducts.appendChild(document.createTextNode('Products'));
+                banner.appendChild(jumpProducts);
+                var jumpScan = el('a', {className: 'btn btn-sm btn-outline', href: 'https://gnosisscan.io/address/' + paymentFilterSeller,
+                    target: '_blank', style: 'text-decoration:none;margin-left:4px;'});
+                jumpScan.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square', style: 'margin-right:4px;'}));
+                jumpScan.appendChild(document.createTextNode('Gnosisscan'));
+                banner.appendChild(jumpScan);
+            }
             var clearBtn = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:auto;', onClick: clearPaymentFilter});
             clearBtn.appendChild(el('i', {className: 'fas fa-xmark', style: 'margin-right:4px;'}));
             clearBtn.appendChild(document.createTextNode('Clear'));

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -335,9 +335,9 @@
             <h1><i class="fas fa-store" style="margin-right: 8px;"></i>Marketplace Explorer</h1>
         </div>
         <div class="header-right">
-            <div class="wallet-status" id="walletStatus">
+            <div class="wallet-status" id="walletStatus" style="display:none;">
                 <span class="dot" id="walletDot"></span>
-                <span id="walletText">Not connected</span>
+                <span id="walletText"></span>
             </div>
             <div class="header-links">
                 <a href="index.html"><i class="fas fa-home"></i> Tools</a>
@@ -410,8 +410,9 @@
             document.getElementById('apiUrlDisplay').textContent = apiBase;
             // Reset and reload
             authToken = null; authAddress = null; signer = null; provider = null;
+            document.getElementById('walletStatus').style.display = 'none';
             document.getElementById('walletDot').classList.remove('connected');
-            document.getElementById('walletText').textContent = 'Not connected';
+            document.getElementById('walletText').textContent = '';
             catalogItems = []; catalogCursor = null; sellersList = [];
             loadSellersAndCatalog();
             renderInventoryForm();
@@ -770,6 +771,7 @@
     }
 
     function updateWalletStatus(address, authed) {
+        document.getElementById('walletStatus').style.display = '';
         document.getElementById('walletDot').classList.add('connected');
         document.getElementById('walletText').textContent = truncAddr(address) + (authed ? ' (authed)' : '');
     }

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -6,6 +6,7 @@
     <title>Marketplace Explorer</title>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
     <style>
         :root {
             --primary: #191568;
@@ -16,6 +17,8 @@
             --text: #191568;
             --text-muted: #666;
             --error: #ef4444;
+            --warning: #f59e0b;
+            --success: #22c55e;
         }
         * { box-sizing: border-box; margin: 0; }
         body {
@@ -35,6 +38,12 @@
             flex-wrap: wrap;
         }
         header h1 { margin: 0; font-weight: 600; font-size: 1.3rem; }
+        .header-right {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            flex-wrap: wrap;
+        }
         .header-links a {
             color: rgba(255,255,255,0.8);
             text-decoration: none;
@@ -42,6 +51,21 @@
             transition: color 0.2s;
         }
         .header-links a:hover { color: #fff; }
+        .wallet-status {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.85rem;
+            padding: 4px 12px;
+            background: rgba(255,255,255,0.1);
+            border-radius: 20px;
+        }
+        .wallet-status .dot {
+            width: 8px; height: 8px;
+            border-radius: 50%;
+            background: var(--text-muted);
+        }
+        .wallet-status .dot.connected { background: var(--success); }
         .container {
             max-width: 1100px;
             margin: 20px auto;
@@ -90,6 +114,15 @@
             border-bottom-color: var(--accent);
             font-weight: 600;
         }
+        .tab-btn .auth-badge {
+            font-size: 0.7rem;
+            background: var(--warning);
+            color: #fff;
+            padding: 1px 5px;
+            border-radius: 8px;
+            margin-left: 6px;
+            vertical-align: middle;
+        }
         .tab-content { display: none; }
         .tab-content.active { display: block; }
 
@@ -111,6 +144,8 @@
         .btn-sm { padding: 6px 14px; font-size: 0.85rem; border-radius: 4px; }
         .btn-outline { background: transparent; color: var(--primary); border: 1px solid var(--border); }
         .btn-outline:hover { background: var(--border); }
+        .btn-wallet { background: #f6851b; }
+        .btn-wallet:hover { background: #e2761b; }
 
         /* Card grid */
         .card-grid {
@@ -222,6 +257,70 @@
             color: var(--text-muted); font-size: 0.85rem; padding: 2px;
         }
         .copy-btn:hover { color: var(--primary); }
+        .clickable-row { cursor: pointer; }
+
+        /* Auth panel */
+        .auth-panel {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 30px;
+            text-align: center;
+            max-width: 450px;
+            margin: 30px auto;
+        }
+        .auth-panel h3 { margin-bottom: 8px; }
+        .auth-panel p { color: var(--text-muted); margin-bottom: 16px; }
+        .auth-steps {
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+
+        /* Order sub-tabs */
+        .sub-tabs {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 16px;
+        }
+        .sub-tab {
+            padding: 6px 16px;
+            border: 1px solid var(--border);
+            border-radius: 20px;
+            background: transparent;
+            font-family: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .sub-tab.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+        .sub-tab:hover:not(.active) { background: #f0eef9; }
+
+        /* Status badge */
+        .status-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+        .status-badge.open { background: #dcfce7; color: #166534; }
+        .status-badge.paid { background: #dbeafe; color: #1e40af; }
+        .status-badge.completed { background: #e0e7ff; color: #3730a3; }
+        .status-badge.cancelled { background: #fee2e2; color: #991b1b; }
+
+        /* Order detail */
+        .order-detail {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 20px;
+            margin-top: 16px;
+        }
+        .order-detail h3 { margin-bottom: 12px; }
+        .detail-row { display: flex; gap: 8px; margin-bottom: 6px; font-size: 0.9rem; }
+        .detail-row .label { font-weight: 600; min-width: 140px; color: var(--text-muted); }
 
         @media (max-width: 600px) {
             .form-row { flex-direction: column; }
@@ -235,15 +334,25 @@
         <div>
             <h1><i class="fas fa-store" style="margin-right: 8px;"></i>Marketplace Explorer</h1>
         </div>
-        <div class="header-links">
-            <a href="index.html"><i class="fas fa-home"></i> Tools</a>
+        <div class="header-right">
+            <div class="wallet-status" id="walletStatus">
+                <span class="dot" id="walletDot"></span>
+                <span id="walletText">Not connected</span>
+            </div>
+            <div class="header-links">
+                <a href="index.html"><i class="fas fa-home"></i> Tools</a>
+            </div>
         </div>
     </header>
 
     <div class="container">
         <div class="api-config">
             <i class="fas fa-server"></i>
-            API: <code id="apiUrlDisplay"></code>
+            <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
+                <option value="https://rpc.aboutcircles.com/market">Production</option>
+                <option value="https://staging.aboutcircles.com/market">Staging</option>
+            </select>
+            <code id="apiUrlDisplay"></code>
         </div>
 
         <div class="tab-bar" id="tabBar"></div>
@@ -254,6 +363,10 @@
 
         <div class="tab-content" id="tab-sellers">
             <div id="sellersContent"></div>
+        </div>
+
+        <div class="tab-content" id="tab-orders">
+            <div id="ordersContent"></div>
         </div>
 
         <div class="tab-content" id="tab-inventory">
@@ -272,13 +385,38 @@
     var catalogCursor = null;
     var catalogItems = [];
     var currentTab = 'catalog';
+    var authToken = null;
+    var authAddress = null;
+    var signer = null;
+    var provider = null;
+    var orderSubTab = 'buyer';
+    var orderPage = 1;
 
     // ─── Init ────────────────────────────────────────────────────────
     (function init() {
         var params = new URLSearchParams(window.location.search);
         var override = params.get('marketplaceApi') || params.get('api');
         if (override) apiBase = override.replace(/\/+$/, '');
+
+        var sel = document.getElementById('endpointSelect');
+        // Set dropdown to match current apiBase if it matches an option
+        for (var i = 0; i < sel.options.length; i++) {
+            if (sel.options[i].value === apiBase) { sel.selectedIndex = i; break; }
+        }
         document.getElementById('apiUrlDisplay').textContent = apiBase;
+
+        sel.addEventListener('change', function() {
+            apiBase = this.value;
+            document.getElementById('apiUrlDisplay').textContent = apiBase;
+            // Reset and reload
+            authToken = null; authAddress = null; signer = null; provider = null;
+            document.getElementById('walletDot').classList.remove('connected');
+            document.getElementById('walletText').textContent = 'Not connected';
+            catalogItems = []; catalogCursor = null; sellersList = [];
+            loadSellersAndCatalog();
+            renderInventoryForm();
+        });
+
         buildTabs();
         loadSellersAndCatalog();
         renderInventoryForm();
@@ -328,6 +466,7 @@
     var TABS = [
         {id: 'catalog', label: 'Catalog', icon: 'fa-boxes-stacked'},
         {id: 'sellers', label: 'Sellers', icon: 'fa-users'},
+        {id: 'orders', label: 'Orders', icon: 'fa-receipt', auth: true},
         {id: 'inventory', label: 'Inventory', icon: 'fa-warehouse'}
     ];
 
@@ -342,6 +481,7 @@
             });
             btn.appendChild(el('i', {className: 'fas ' + t.icon, style: 'margin-right:6px;'}));
             btn.appendChild(document.createTextNode(t.label));
+            if (t.auth) btn.appendChild(el('span', {className: 'auth-badge'}, 'AUTH'));
             bar.appendChild(btn);
         });
     }
@@ -354,6 +494,7 @@
         document.querySelectorAll('.tab-content').forEach(function(tc) {
             tc.classList.toggle('active', tc.id === 'tab-' + id);
         });
+        if (id === 'orders') renderOrdersTab();
     }
 
     // ─── Catalog + Sellers ───────────────────────────────────────────
@@ -574,6 +715,253 @@
         form.appendChild(row);
         container.appendChild(form);
         container.appendChild(el('div', {id: 'inventoryResult'}));
+    }
+
+    // ─── SIWE Auth ───────────────────────────────────────────────────
+    async function connectWallet() {
+        if (!window.ethereum) {
+            alert('Please install a Web3 wallet (e.g. MetaMask).');
+            return;
+        }
+        try {
+            provider = new ethers.providers.Web3Provider(window.ethereum);
+            await provider.send('eth_requestAccounts', []);
+            signer = provider.getSigner();
+            var address = await signer.getAddress();
+            updateWalletStatus(address, false);
+            return address;
+        } catch (err) {
+            console.error('Wallet connect failed:', err);
+            throw err;
+        }
+    }
+
+    async function signIn() {
+        try {
+            var address = signer ? await signer.getAddress() : await connectWallet();
+
+            var challengeRes = await fetch(apiBase + '/api/auth/challenge', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({address: address, chainId: 100})
+            });
+            if (!challengeRes.ok) throw new Error('Challenge failed: ' + challengeRes.status);
+            var challenge = await challengeRes.json();
+
+            var signature = await signer.signMessage(challenge.message);
+
+            var verifyRes = await fetch(apiBase + '/api/auth/verify', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({challengeId: challenge.challengeId, signature: signature})
+            });
+            if (!verifyRes.ok) throw new Error('Verification failed: ' + verifyRes.status);
+            var verifyData = await verifyRes.json();
+
+            authToken = verifyData.token;
+            authAddress = verifyData.address || address;
+            updateWalletStatus(authAddress, true);
+            renderOrdersTab();
+        } catch (err) {
+            console.error('Sign in failed:', err);
+            var oc = document.getElementById('ordersContent');
+            if (oc) showError(oc, 'Authentication failed: ' + err.message);
+        }
+    }
+
+    function updateWalletStatus(address, authed) {
+        document.getElementById('walletDot').classList.add('connected');
+        document.getElementById('walletText').textContent = truncAddr(address) + (authed ? ' (authed)' : '');
+    }
+
+    function authedFetch(url) {
+        return fetch(url, { headers: {'Authorization': 'Bearer ' + authToken} });
+    }
+
+    // ─── Orders tab ──────────────────────────────────────────────────
+    function renderOrdersTab() {
+        var container = clearEl('ordersContent');
+
+        if (!authToken) {
+            var panel = el('div', {className: 'auth-panel'});
+            panel.appendChild(el('h3', {}, 'Authentication Required'));
+            panel.appendChild(el('p', {}, 'Connect your wallet and sign in with Ethereum (SIWE) to view orders.'));
+            var steps = el('div', {className: 'auth-steps'});
+            var connectBtn = el('button', {className: 'btn btn-wallet', onClick: connectWallet});
+            connectBtn.appendChild(el('i', {className: 'fas fa-plug', style: 'margin-right:6px;'}));
+            connectBtn.appendChild(document.createTextNode('Connect Wallet'));
+            steps.appendChild(connectBtn);
+            var signBtn = el('button', {className: 'btn', onClick: signIn});
+            signBtn.appendChild(el('i', {className: 'fas fa-signature', style: 'margin-right:6px;'}));
+            signBtn.appendChild(document.createTextNode('Sign In'));
+            steps.appendChild(signBtn);
+            panel.appendChild(steps);
+            container.appendChild(panel);
+            return;
+        }
+
+        var subTabs = el('div', {className: 'sub-tabs'});
+        ['buyer', 'seller'].forEach(function(role) {
+            subTabs.appendChild(el('button', {
+                className: 'sub-tab' + (orderSubTab === role ? ' active' : ''),
+                onClick: function() { orderSubTab = role; orderPage = 1; renderOrdersTab(); }
+            }, 'As ' + role.charAt(0).toUpperCase() + role.slice(1)));
+        });
+        container.appendChild(subTabs);
+        container.appendChild(el('div', {id: 'ordersListContainer'}));
+        loadOrders();
+    }
+
+    async function loadOrders() {
+        var container = document.getElementById('ordersListContainer');
+        if (!container) return;
+        showLoading(container);
+
+        var endpoint = orderSubTab === 'buyer'
+            ? '/api/cart/v1/orders/by-buyer'
+            : '/api/cart/v1/orders/by-seller';
+
+        try {
+            var res = await authedFetch(apiBase + endpoint + '?page=' + orderPage + '&pageSize=20');
+            if (!res.ok) {
+                if (res.status === 401) { authToken = null; renderOrdersTab(); return; }
+                throw new Error('Orders API: ' + res.status);
+            }
+            var data = await res.json();
+            var orders = data.orders || data.items || data || [];
+            var total = data.total || data.totalCount || orders.length;
+            renderOrders(orders, total);
+        } catch (err) {
+            showError(container, 'Failed to load orders: ' + err.message);
+        }
+    }
+
+    function renderOrders(orders, total) {
+        var container = clearEl('ordersListContainer');
+        if (!orders.length) {
+            container.appendChild(el('div', {className: 'empty-state'}, 'No orders found.'));
+            return;
+        }
+
+        var table = el('table');
+        var thead = el('thead');
+        var hr = el('tr');
+        ['Order #', 'Status', 'Items', 'Payment Ref', 'Date'].forEach(function(h) { hr.appendChild(el('th', {}, h)); });
+        thead.appendChild(hr);
+        table.appendChild(thead);
+
+        var tbody = el('tbody');
+        orders.forEach(function(order) {
+            var row = el('tr', {className: 'clickable-row'});
+            row.addEventListener('click', function() { viewOrderDetail(order.orderId || order.id); });
+            row.appendChild(el('td', {}, String(order.orderNumber || order.orderId || order.id || '')));
+
+            var statusTd = el('td');
+            statusTd.appendChild(el('span', {className: 'status-badge ' + (order.status || '').toLowerCase()}, order.status || 'unknown'));
+            row.appendChild(statusTd);
+
+            var itemCount = order.items ? order.items.length : (order.itemCount || '?');
+            row.appendChild(el('td', {}, String(itemCount) + ' item(s)'));
+            row.appendChild(el('td', {className: 'address-cell'}, order.paymentReference || 'N/A'));
+
+            var dateStr = order.createdAt || order.date || '';
+            if (dateStr) try { dateStr = new Date(dateStr).toLocaleDateString(); } catch(e) {}
+            row.appendChild(el('td', {}, dateStr));
+            tbody.appendChild(row);
+        });
+        table.appendChild(tbody);
+        container.appendChild(table);
+
+        var totalPages = Math.ceil(total / 20) || 1;
+        if (totalPages > 1) {
+            var pag = el('div', {className: 'pagination'});
+            pag.appendChild(el('button', {
+                className: 'btn btn-sm btn-outline',
+                disabled: orderPage <= 1 ? 'true' : undefined,
+                onClick: function() { orderPage--; loadOrders(); }
+            }, 'Prev'));
+            pag.appendChild(el('span', {}, 'Page ' + orderPage + ' of ' + totalPages));
+            pag.appendChild(el('button', {
+                className: 'btn btn-sm btn-outline',
+                disabled: orderPage >= totalPages ? 'true' : undefined,
+                onClick: function() { orderPage++; loadOrders(); }
+            }, 'Next'));
+            container.appendChild(pag);
+        }
+        container.appendChild(el('div', {id: 'orderDetailContainer'}));
+    }
+
+    async function viewOrderDetail(orderId) {
+        var dc = document.getElementById('orderDetailContainer');
+        if (!dc) return;
+        dc.textContent = '';
+        showLoading(dc);
+
+        try {
+            var [orderRes, historyRes] = await Promise.allSettled([
+                authedFetch(apiBase + '/api/cart/v1/orders/' + orderId),
+                authedFetch(apiBase + '/api/cart/v1/orders/' + orderId + '/status-history')
+            ]);
+
+            dc.textContent = '';
+            var detail = el('div', {className: 'order-detail'});
+
+            if (orderRes.status === 'fulfilled' && orderRes.value.ok) {
+                var order = await orderRes.value.json();
+                detail.appendChild(el('h3', {}, 'Order #' + (order.orderNumber || order.orderId || orderId)));
+
+                [['Status', order.status], ['Order ID', order.orderId || order.id],
+                 ['Payment Reference', order.paymentReference],
+                 ['Created', order.createdAt ? new Date(order.createdAt).toLocaleString() : null],
+                 ['Updated', order.updatedAt ? new Date(order.updatedAt).toLocaleString() : null]
+                ].forEach(function(f) {
+                    if (!f[1]) return;
+                    var r = el('div', {className: 'detail-row'});
+                    r.appendChild(el('span', {className: 'label'}, f[0] + ':'));
+                    r.appendChild(el('span', {}, String(f[1])));
+                    detail.appendChild(r);
+                });
+
+                if (order.items && order.items.length) {
+                    detail.appendChild(el('h4', {style: 'margin-top:12px;margin-bottom:6px;'}, 'Items'));
+                    var it = el('table');
+                    var ith = el('thead'); var ithr = el('tr');
+                    ['Name', 'SKU', 'Qty', 'Price'].forEach(function(h) { ithr.appendChild(el('th', {}, h)); });
+                    ith.appendChild(ithr); it.appendChild(ith);
+                    var itb = el('tbody');
+                    order.items.forEach(function(item) {
+                        var r = el('tr');
+                        r.appendChild(el('td', {}, item.name || item.title || 'N/A'));
+                        r.appendChild(el('td', {}, item.sku || 'N/A'));
+                        r.appendChild(el('td', {}, String(item.quantity || item.qty || 1)));
+                        r.appendChild(el('td', {}, String(item.price != null ? item.price : 'N/A')));
+                        itb.appendChild(r);
+                    });
+                    it.appendChild(itb); detail.appendChild(it);
+                }
+            } else {
+                detail.appendChild(el('div', {className: 'error-msg'}, 'Failed to load order detail.'));
+            }
+
+            if (historyRes.status === 'fulfilled' && historyRes.value.ok) {
+                var hist = await historyRes.value.json();
+                var arr = hist.history || hist || [];
+                if (arr.length) {
+                    detail.appendChild(el('h4', {style: 'margin-top:16px;margin-bottom:6px;'}, 'Status History'));
+                    arr.forEach(function(h) {
+                        var r = el('div', {className: 'detail-row'});
+                        r.appendChild(el('span', {className: 'status-badge ' + (h.status || '').toLowerCase()}, h.status || ''));
+                        if (h.timestamp || h.createdAt)
+                            r.appendChild(el('span', {style: 'margin-left:8px;color:var(--text-muted);font-size:0.85rem;'},
+                                new Date(h.timestamp || h.createdAt).toLocaleString()));
+                        detail.appendChild(r);
+                    });
+                }
+            }
+            dc.appendChild(detail);
+        } catch (err) {
+            showError(dc, 'Failed to load order: ' + err.message);
+        }
     }
 
     async function checkInventory() {

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -269,6 +269,23 @@
             color: var(--text-muted); font-size: 0.85rem; padding: 2px;
         }
         .copy-btn:hover { color: var(--primary); }
+        .tab-filter {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+        .tab-filter input {
+            flex: 1;
+            max-width: 320px;
+            padding: 6px 12px 6px 32px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-family: inherit;
+            font-size: 0.85rem;
+            background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='%23999' viewBox='0 0 512 512'%3E%3Cpath d='M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208z'/%3E%3C/svg%3E") 10px center no-repeat var(--card-bg);
+        }
+        .tab-filter input:focus { outline: 2px solid var(--primary); border-color: transparent; }
         .clickable-row { cursor: pointer; }
 
         /* Auth panel */
@@ -488,9 +505,9 @@
     function syncUrlState() {
         var params = new URLSearchParams();
         if (currentTab !== 'catalog') params.set('tab', currentTab);
-        if (catalogFilterSeller) params.set('seller', catalogFilterSeller);
-        if (paymentFilterSeller) params.set('payee', paymentFilterSeller);
-        if (paymentFilterGateway) params.set('gateway', paymentFilterGateway);
+        if (currentTab === 'catalog' && catalogFilterSeller) params.set('seller', catalogFilterSeller);
+        if (currentTab === 'payments' && paymentFilterSeller) params.set('payee', paymentFilterSeller);
+        if (currentTab === 'payments' && paymentFilterGateway) params.set('gateway', paymentFilterGateway);
         if (apiBase !== DEFAULT_API) params.set('api', apiBase);
         var qs = params.toString();
         window.history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
@@ -573,6 +590,25 @@
         syncUrlState();
     }
 
+    // Shared fuzzy filter — hides children of `container` whose text doesn't match query
+    function addFilterBar(container, placeholder) {
+        var bar = el('div', {className: 'tab-filter'});
+        var input = el('input', {type: 'text', placeholder: placeholder || 'Filter...'});
+        input.addEventListener('input', function() {
+            var q = this.value.toLowerCase().trim();
+            // Find the filterable container (card-grid or table tbody)
+            var grid = container.querySelector('.card-grid');
+            var tbody = container.querySelector('tbody');
+            var items = grid ? grid.children : (tbody ? tbody.children : []);
+            for (var i = 0; i < items.length; i++) {
+                var text = (items[i].textContent || '').toLowerCase();
+                items[i].style.display = (!q || text.indexOf(q) !== -1) ? '' : 'none';
+            }
+        });
+        bar.appendChild(input);
+        return bar;
+    }
+
     function renderCatalog() {
         var container = clearEl('catalogContent');
 
@@ -604,6 +640,8 @@
             banner.appendChild(clearBtn);
             container.appendChild(banner);
         }
+
+        if (catalogItems.length) container.appendChild(addFilterBar(container, 'Filter products...'));
 
         if (!catalogItems.length) {
             container.appendChild(el('div', {className: 'empty-state'}, 'No catalog items found.'));
@@ -673,27 +711,6 @@
             if (sku) {
                 metaBottom.appendChild(el('div', {style: 'font-family:monospace;font-size:0.8rem;'}, sku));
             }
-            // Availability badge — lazy fetch from feed URL if available
-            var availFeed = offer.availabilityFeed || null;
-            if (availFeed) {
-                var availBadge = el('div', {style: 'margin-top:4px;'});
-                availBadge.appendChild(el('span', {style: 'font-size:0.75rem;color:var(--text-muted);'}, 'checking stock...'));
-                metaBottom.appendChild(availBadge);
-                (function(badge, url) {
-                    fetch(url).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
-                        badge.textContent = '';
-                        if (!data) return;
-                        var avail = typeof data === 'object' ? (data.available || data.inStock || data.quantity) : data;
-                        if (avail === true || avail > 0) {
-                            badge.appendChild(el('span', {style: 'font-size:0.75rem;padding:2px 6px;border-radius:8px;background:#dcfce7;color:#166534;'}, 'In stock'));
-                        } else if (avail === false || avail === 0) {
-                            badge.appendChild(el('span', {style: 'font-size:0.75rem;padding:2px 6px;border-radius:8px;background:#fee2e2;color:#991b1b;'}, 'Out of stock'));
-                        } else {
-                            badge.appendChild(el('span', {style: 'font-size:0.75rem;color:var(--text-muted);'}, 'Stock: ' + JSON.stringify(data)));
-                        }
-                    }).catch(function() { badge.textContent = ''; });
-                })(availBadge, availFeed);
-            }
             card.appendChild(metaBottom);
 
             grid.appendChild(card);
@@ -715,6 +732,8 @@
     // ─── Sellers (card layout) ──────────────────────────────────────
     function renderSellersTable() {
         var container = clearEl('sellersContent');
+
+        if (sellersList.length) container.appendChild(addFilterBar(container, 'Filter sellers...'));
 
         if (!sellersList.length) {
             container.appendChild(el('div', {className: 'empty-state'}, 'No sellers found.'));
@@ -1150,6 +1169,8 @@
         }
 
         // Payments table
+        if (allPayments.length) container.appendChild(addFilterBar(container, 'Filter payments...'));
+
         if (!allPayments.length) {
             container.appendChild(el('div', {className: 'empty-state'}, 'No payments found.'));
             return;

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -1175,16 +1175,21 @@
 
             // Payer — clickable to filter
             var payerCell = el('td', {className: 'address-cell'});
-            payerCell.appendChild(el('a', {href: 'https://gnosisscan.io/address/' + r[0], target: '_blank', className: 'seller-link'}, truncAddr(r[0])));
+            var payerLink = el('a', {href: 'profileChecker.html?address=' + r[0], target: '_blank',
+                className: 'seller-link'}, truncAddr(r[0]));
+            payerCell.appendChild(payerLink);
+            // Enrich payer name
+            (function(link, addr) {
+                enrichSeller(addr).then(function(info) { if (info.name) link.textContent = info.name; });
+            })(payerLink, r[0]);
             row.appendChild(payerCell);
 
-            // Payee — clickable to filter payments
+            // Payee — link to seller card
             var payeeCell = el('td', {className: 'address-cell'});
             var payeeLink = el('a', {href: '#', className: 'seller-link',
-                onClick: (function(a) { return function(e) { e.preventDefault(); filterPaymentsBySeller(a); }; })(r[1])
+                onClick: (function(a) { return function(e) { e.preventDefault(); scrollToSeller(a); }; })(r[1])
             }, truncAddr(r[1]));
             payeeCell.appendChild(payeeLink);
-            // Enrich payee name
             (function(link, addr) {
                 enrichSeller(addr).then(function(info) { if (info.name) link.textContent = info.name; });
             })(payeeLink, r[1]);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -405,41 +405,7 @@
     var orderSubTab = 'buyer';
     var orderPage = 1;
 
-    // ─── Init ────────────────────────────────────────────────────────
-    // Re-init on bfcache restore (Brave/Safari back-forward cache)
-    window.addEventListener('pageshow', function(e) {
-        if (e.persisted && !catalogItems.length) loadSellersAndCatalog();
-    });
-
-    (function init() {
-        var params = new URLSearchParams(window.location.search);
-        var override = params.get('marketplaceApi') || params.get('api');
-        if (override) apiBase = override.replace(/\/+$/, '');
-
-        var sel = document.getElementById('endpointSelect');
-        // Set dropdown to match current apiBase if it matches an option
-        for (var i = 0; i < sel.options.length; i++) {
-            if (sel.options[i].value === apiBase) { sel.selectedIndex = i; break; }
-        }
-        document.getElementById('apiUrlDisplay').textContent = apiBase;
-
-        sel.addEventListener('change', function() {
-            apiBase = this.value;
-            document.getElementById('apiUrlDisplay').textContent = apiBase;
-            // Reset and reload
-            authToken = null; authAddress = null; signer = null; provider = null;
-            document.getElementById('walletStatus').style.display = 'none';
-            document.getElementById('walletDot').classList.remove('connected');
-            document.getElementById('walletText').textContent = '';
-            catalogItems = []; catalogCursor = null; sellersList = [];
-            loadSellersAndCatalog();
-            renderInventoryForm();
-        });
-
-        buildTabs();
-        renderInventoryForm();
-        loadSellersAndCatalog();
-    })();
+    // ─── Init (hoisted — actual call is at end of script) ─────────
 
     // ─── DOM helper ──────────────────────────────────────────────────
     function el(tag, attrs, children) {
@@ -1140,6 +1106,39 @@
             showError(resultDiv, 'Inventory check failed: ' + err.message);
         }
     }
+
+    // ─── Init (runs after all declarations) ──────────────────────────
+    window.addEventListener('pageshow', function(e) {
+        if (e.persisted && !catalogItems.length) loadSellersAndCatalog();
+    });
+
+    (function init() {
+        var params = new URLSearchParams(window.location.search);
+        var override = params.get('marketplaceApi') || params.get('api');
+        if (override) apiBase = override.replace(/\/+$/, '');
+
+        var sel = document.getElementById('endpointSelect');
+        for (var i = 0; i < sel.options.length; i++) {
+            if (sel.options[i].value === apiBase) { sel.selectedIndex = i; break; }
+        }
+        document.getElementById('apiUrlDisplay').textContent = apiBase;
+
+        sel.addEventListener('change', function() {
+            apiBase = this.value;
+            document.getElementById('apiUrlDisplay').textContent = apiBase;
+            authToken = null; authAddress = null; signer = null; provider = null;
+            document.getElementById('walletStatus').style.display = 'none';
+            document.getElementById('walletDot').classList.remove('connected');
+            document.getElementById('walletText').textContent = '';
+            catalogItems = []; catalogCursor = null; sellersList = []; sellerInfoCache = {};
+            loadSellersAndCatalog();
+            renderInventoryForm();
+        });
+
+        buildTabs();
+        renderInventoryForm();
+        loadSellersAndCatalog();
+    })();
     </script>
 </body>
 </html>

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -386,9 +386,6 @@
             <div id="ordersContent"></div>
         </div>
 
-        <div class="tab-content" id="tab-inventory">
-            <div id="inventoryContent"></div>
-        </div>
     </div>
 
     <script>
@@ -457,8 +454,7 @@
         {id: 'catalog', label: 'Catalog', icon: 'fa-boxes-stacked'},
         {id: 'sellers', label: 'Sellers', icon: 'fa-users'},
         {id: 'payments', label: 'Payments', icon: 'fa-credit-card'},
-        {id: 'orders', label: 'Orders', icon: 'fa-receipt', auth: true},
-        {id: 'inventory', label: 'Inventory', icon: 'fa-warehouse'}
+        {id: 'orders', label: 'Orders', icon: 'fa-receipt', auth: true}
     ];
 
     function buildTabs() {
@@ -676,16 +672,7 @@
                 })(sellerLine, sellerLink, sellerAddr);
             }
             if (sku) {
-                var skuLine = el('div', {style: 'display:flex;align-items:center;gap:4px;'});
-                skuLine.appendChild(document.createTextNode(sku));
-                if (sellerAddr) {
-                    var stockLink = el('a', {href: '#', style: 'color:var(--primary);text-decoration:none;margin-left:auto;',
-                        onClick: (function(s, a) { return function(e) { e.preventDefault(); checkInventoryFor(a, s); }; })(sku, sellerAddr)});
-                    stockLink.appendChild(el('i', {className: 'fas fa-warehouse', style: 'margin-right:3px;font-size:0.75em;'}));
-                    stockLink.appendChild(document.createTextNode('stock'));
-                    skuLine.appendChild(stockLink);
-                }
-                metaBottom.appendChild(skuLine);
+                metaBottom.appendChild(el('div', {style: 'font-family:monospace;font-size:0.8rem;'}, sku));
             }
             card.appendChild(metaBottom);
 
@@ -1060,7 +1047,7 @@
 
         var stats = el('div', {style: 'display:flex;gap:16px;margin-bottom:16px;flex-wrap:wrap;'});
         [['Payments', allPayments.length], ['Volume', totalVolume.toFixed(2) + ' CRC'],
-         ['Unique Payers', Object.keys(uniquePayers).length], ['Unique Payees', Object.keys(uniquePayees).length]
+         ['Buyers', Object.keys(uniquePayers).length], ['Sellers', Object.keys(uniquePayees).length]
         ].forEach(function(s) {
             var card = el('div', {style: 'background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:12px 16px;min-width:120px;'});
             card.appendChild(el('div', {style: 'font-size:0.8rem;color:var(--text-muted);'}, s[0]));
@@ -1233,48 +1220,6 @@
     // Used by sellers table → payments, catalog → seller filter, etc.
     function viewSellerPayments(addr) { filterPaymentsBySeller(addr); }
 
-    // ─── Inventory ───────────────────────────────────────────────────
-    function checkInventoryFor(seller, sku) {
-        switchTab('inventory');
-        setTimeout(function() {
-            var sellerEl = document.getElementById('invSeller');
-            var skuEl = document.getElementById('invSku');
-            if (sellerEl) sellerEl.value = seller;
-            if (skuEl) skuEl.value = sku;
-            checkInventory();
-        }, 50);
-    }
-
-    function renderInventoryForm() {
-        var container = clearEl('inventoryContent');
-
-        var form = el('div');
-        var row = el('div', {className: 'form-row'});
-
-        var chainGroup = el('div', {className: 'form-group'});
-        chainGroup.appendChild(el('label', {}, 'Chain ID'));
-        chainGroup.appendChild(el('input', {type: 'text', id: 'invChainId', value: '100', style: 'width:80px;'}));
-        row.appendChild(chainGroup);
-
-        var sellerGroup = el('div', {className: 'form-group', style: 'flex:1;'});
-        sellerGroup.appendChild(el('label', {}, 'Seller Address'));
-        sellerGroup.appendChild(el('input', {type: 'text', id: 'invSeller', placeholder: '0x...'}));
-        row.appendChild(sellerGroup);
-
-        var skuGroup = el('div', {className: 'form-group'});
-        skuGroup.appendChild(el('label', {}, 'SKU'));
-        skuGroup.appendChild(el('input', {type: 'text', id: 'invSku', placeholder: 'Product SKU'}));
-        row.appendChild(skuGroup);
-
-        var btnGroup = el('div', {className: 'form-group'});
-        btnGroup.appendChild(el('label', {}, '\u00A0'));
-        btnGroup.appendChild(el('button', {className: 'btn', onClick: checkInventory}, 'Check'));
-        row.appendChild(btnGroup);
-
-        form.appendChild(row);
-        container.appendChild(form);
-        container.appendChild(el('div', {id: 'inventoryResult'}));
-    }
 
     // ─── SIWE Auth ───────────────────────────────────────────────────
     async function connectWallet() {
@@ -1525,53 +1470,6 @@
         }
     }
 
-    async function checkInventory() {
-        var chainId = document.getElementById('invChainId').value.trim() || '100';
-        var seller = document.getElementById('invSeller').value.trim();
-        var sku = document.getElementById('invSku').value.trim();
-
-        if (!seller || !sku) {
-            showError(document.getElementById('inventoryResult'), 'Please enter seller address and SKU.');
-            return;
-        }
-
-        var resultDiv = clearEl('inventoryResult');
-        showLoading(resultDiv);
-
-        try {
-            var [avail, inv] = await Promise.allSettled([
-                fetch(apiBase + '/inventory/availability/' + chainId + '/' + seller + '/' + encodeURIComponent(sku)).then(function(r) { return r.ok ? r.json() : null; }),
-                fetch(apiBase + '/inventory/inventory/' + chainId + '/' + seller + '/' + encodeURIComponent(sku)).then(function(r) { return r.ok ? r.json() : null; })
-            ]);
-
-            resultDiv.textContent = '';
-            var card = el('div', {className: 'product-card', style: 'max-width:400px;'});
-
-            card.appendChild(el('h3', {}, 'Inventory for SKU: ' + sku));
-
-            if (avail.status === 'fulfilled' && avail.value != null) {
-                var availVal = typeof avail.value === 'object' ? JSON.stringify(avail.value) : String(avail.value);
-                card.appendChild(el('div', {}, [
-                    el('strong', {}, 'Availability: '),
-                    document.createTextNode(availVal)
-                ]));
-            }
-            if (inv.status === 'fulfilled' && inv.value != null) {
-                var invVal = typeof inv.value === 'object' ? JSON.stringify(inv.value, null, 2) : String(inv.value);
-                card.appendChild(el('div', {style: 'margin-top:8px;'}, [
-                    el('strong', {}, 'Inventory Details:'),
-                    el('pre', {style: 'margin-top:4px;font-size:0.85rem;white-space:pre-wrap;'}, invVal)
-                ]));
-            }
-            if ((!avail.value && avail.status === 'fulfilled') && (!inv.value && inv.status === 'fulfilled')) {
-                card.appendChild(el('div', {className: 'meta'}, 'No inventory data found for this combination.'));
-            }
-
-            resultDiv.appendChild(card);
-        } catch (err) {
-            showError(resultDiv, 'Inventory check failed: ' + err.message);
-        }
-    }
 
     // ─── Init (runs after all declarations) ──────────────────────────
     window.addEventListener('pageshow', function(e) {
@@ -1598,7 +1496,7 @@
             document.getElementById('walletText').textContent = '';
             catalogItems = []; catalogCursor = null; sellersList = []; sellerInfoCache = {};
             loadSellersAndCatalog();
-            renderInventoryForm();
+
         });
 
         // Restore state from URL

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -742,13 +742,19 @@
             if (rpcRes.ok) {
                 var rpcData = await rpcRes.json();
                 var rows = rpcData.result && rpcData.result.rows;
-                if (rows && rows.length) info.type = rows[0][1] || null;
+                if (rows && rows.length) {
+                    var raw = (rows[0][1] || '').toLowerCase();
+                    if (raw.indexOf('human') !== -1) info.type = 'human';
+                    else if (raw.indexOf('organization') !== -1) info.type = 'organization';
+                    else if (raw.indexOf('group') !== -1) info.type = 'group';
+                    else info.type = raw;
+                }
             }
         } catch (e) {}
 
         // CID history availability (quick check)
         try {
-            var histRes = await fetch(PROFILES_API + '/avatar/' + key + '/history?limit=1&offset=0');
+            var histRes = await fetch('https://profiles.staging.aboutcircles.com/avatar/' + key + '/history?limit=1&offset=0');
             if (histRes.ok) {
                 var histData = await histRes.json();
                 var entries = Array.isArray(histData) ? histData : (histData.history || []);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -105,7 +105,6 @@
             border-bottom: 2px solid var(--border);
             margin-bottom: 20px;
             gap: 4px;
-            overflow-x: auto;
         }
         .tab-btn {
             padding: 10px 20px;

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -349,7 +349,7 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
-                <option value="https://market.staging.aboutcircles.com">Staging</option>
+                <option value="https://market-api.staging.aboutcircles.com">Staging</option>
                 <option value="https://market-api.aboutcircles.com/market">Production</option>
             </select>
             <code id="apiUrlDisplay"></code>
@@ -376,7 +376,7 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    var DEFAULT_API = 'https://market.staging.aboutcircles.com';
+    var DEFAULT_API = 'https://market-api.staging.aboutcircles.com';
     var PROFILES_API = 'https://rpc.aboutcircles.com/profiles';
     var OPERATOR = '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b';
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -487,6 +487,18 @@
         });
         if (id === 'orders') renderOrdersTab();
         if (id === 'payments') loadPayments();
+        syncUrlState();
+    }
+
+    function syncUrlState() {
+        var params = new URLSearchParams();
+        if (currentTab !== 'catalog') params.set('tab', currentTab);
+        if (catalogFilterSeller) params.set('seller', catalogFilterSeller);
+        if (paymentFilterSeller) params.set('payee', paymentFilterSeller);
+        if (paymentFilterGateway) params.set('gateway', paymentFilterGateway);
+        if (apiBase !== DEFAULT_API) params.set('api', apiBase);
+        var qs = params.toString();
+        window.history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
     }
 
     // ─── Catalog + Sellers ───────────────────────────────────────────
@@ -557,11 +569,13 @@
         catalogFilterSeller = addr;
         switchTab('catalog');
         loadCatalog(true);
+        syncUrlState();
     }
 
     function clearCatalogFilter() {
         catalogFilterSeller = null;
         loadCatalog(true);
+        syncUrlState();
     }
 
     function renderCatalog() {
@@ -634,48 +648,46 @@
             if (currency) priceStr += ' ' + currency;
             card.appendChild(el('div', {className: 'price'}, priceStr));
 
+            // Bottom meta section — consistent link style
             var sellerAddr = item.seller || p.seller || '';
+            var sku = p.sku || item.sku || '';
+            var metaBottom = el('div', {style: 'margin-top:auto;padding-top:8px;border-top:1px solid var(--border);font-size:0.82rem;color:var(--text-muted);display:flex;flex-direction:column;gap:3px;'});
+
             if (sellerAddr) {
-                var sellerRow = el('div', {className: 'meta', style: 'margin-top:4px;'});
-                sellerRow.appendChild(document.createTextNode('Seller: '));
-                var sellerLink = el('a', {
-                    className: 'seller-link',
-                    href: '#',
+                var sellerLine = el('div', {style: 'display:flex;align-items:center;gap:4px;'});
+                var sellerLink = el('a', {href: '#', style: 'color:var(--primary);text-decoration:none;font-weight:500;',
                     onClick: (function(a) { return function(e) { e.preventDefault(); scrollToSeller(a); }; })(sellerAddr)
                 }, truncAddr(sellerAddr));
-                sellerRow.appendChild(sellerLink);
-                card.appendChild(sellerRow);
-                // Async-enrich seller name + type badge on the card
-                (function(row, link, addr) {
+                sellerLine.appendChild(sellerLink);
+                metaBottom.appendChild(sellerLine);
+                // Async enrich
+                (function(line, link, addr) {
                     enrichSeller(addr).then(function(info) {
                         if (info.name) link.textContent = info.name;
                         if (info.type) {
-                            var badge = el('span', {
-                                style: 'margin-left:4px;font-size:0.7rem;padding:1px 5px;border-radius:8px;' +
-                                    (info.type === 'human' ? 'background:#dcfce7;color:#166534;' :
-                                     info.type === 'organization' ? 'background:#dbeafe;color:#1e40af;' :
+                            line.appendChild(el('span', {
+                                style: 'font-size:0.7rem;padding:1px 5px;border-radius:8px;margin-left:4px;' +
+                                    (info.type === 'organization' ? 'background:#dbeafe;color:#1e40af;' :
+                                     info.type === 'human' ? 'background:#dcfce7;color:#166534;' :
                                      'background:#f3f4f6;color:#374151;')
-                            }, info.type);
-                            row.appendChild(badge);
+                            }, info.type));
                         }
                     });
-                })(sellerRow, sellerLink, sellerAddr);
+                })(sellerLine, sellerLink, sellerAddr);
             }
-
-            var sku = p.sku || item.sku || '';
             if (sku) {
-                var skuRow = el('div', {className: 'meta', style: 'display:flex;align-items:center;gap:6px;'});
-                skuRow.appendChild(document.createTextNode('SKU: ' + sku));
+                var skuLine = el('div', {style: 'display:flex;align-items:center;gap:4px;'});
+                skuLine.appendChild(document.createTextNode(sku));
                 if (sellerAddr) {
-                    var stockBtn = el('button', {className: 'btn btn-sm btn-outline',
-                        style: 'font-size:0.75rem;padding:2px 8px;margin-left:auto;',
-                        onClick: (function(s, a) { return function() { checkInventoryFor(a, s); }; })(sku, sellerAddr)});
-                    stockBtn.appendChild(el('i', {className: 'fas fa-warehouse', style: 'margin-right:3px;'}));
-                    stockBtn.appendChild(document.createTextNode('Stock'));
-                    skuRow.appendChild(stockBtn);
+                    var stockLink = el('a', {href: '#', style: 'color:var(--primary);text-decoration:none;margin-left:auto;',
+                        onClick: (function(s, a) { return function(e) { e.preventDefault(); checkInventoryFor(a, s); }; })(sku, sellerAddr)});
+                    stockLink.appendChild(el('i', {className: 'fas fa-warehouse', style: 'margin-right:3px;font-size:0.75em;'}));
+                    stockLink.appendChild(document.createTextNode('stock'));
+                    skuLine.appendChild(stockLink);
                 }
-                card.appendChild(skuRow);
+                metaBottom.appendChild(skuLine);
             }
+            card.appendChild(metaBottom);
 
             grid.appendChild(card);
         });
@@ -990,6 +1002,7 @@
 
     function filterPaymentsBySeller(addr) {
         paymentFilterSeller = addr;
+        paymentFilterGateway = null;
         paymentsLoaded = false;
         switchTab('payments');
         loadPayments();
@@ -1000,10 +1013,40 @@
         paymentFilterGateway = null;
         paymentsLoaded = false;
         loadPayments();
+        syncUrlState();
     }
 
     function renderPayments() {
         var container = clearEl('paymentsContent');
+
+        // Gateway filter dropdown — scoped to current seller filter if active
+        var relevantGws = Object.values(allGateways);
+        if (paymentFilterSeller) {
+            relevantGws = relevantGws.filter(function(gw) {
+                return gw.owner.toLowerCase() === paymentFilterSeller.toLowerCase();
+            });
+        }
+        if (relevantGws.length) {
+            var filterBar = el('div', {style: 'display:flex;align-items:center;gap:8px;margin-bottom:12px;font-size:0.85rem;'});
+            filterBar.appendChild(el('i', {className: 'fas fa-landmark', style: 'color:var(--text-muted);'}));
+            filterBar.appendChild(document.createTextNode('Gateway: '));
+            var gwSelect = el('select', {style: 'padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;'});
+            gwSelect.appendChild(el('option', {value: ''}, relevantGws.length > 1 ? 'All (' + relevantGws.length + ')' : 'All'));
+            relevantGws.forEach(function(gw) {
+                var info = sellerInfoCache[gw.owner.toLowerCase()];
+                var ownerLabel = info && info.name ? info.name : truncAddr(gw.owner);
+                var opt = el('option', {value: gw.gateway}, truncAddr(gw.gateway) + ' \u2014 ' + ownerLabel);
+                if (paymentFilterGateway && paymentFilterGateway.toLowerCase() === gw.gateway.toLowerCase()) opt.selected = true;
+                gwSelect.appendChild(opt);
+            });
+            gwSelect.addEventListener('change', function() {
+                paymentFilterGateway = this.value || null;
+                paymentsLoaded = false;
+                loadPayments();
+            });
+            filterBar.appendChild(gwSelect);
+            container.appendChild(filterBar);
+        }
 
         // Summary stats
         var totalVolume = 0;
@@ -1558,9 +1601,22 @@
             renderInventoryForm();
         });
 
+        // Restore state from URL
+        var urlTab = params.get('tab');
+        var urlSeller = params.get('seller');
+        var urlPayee = params.get('payee');
+        var urlGateway = params.get('gateway');
+        if (urlSeller) catalogFilterSeller = urlSeller;
+        if (urlPayee) paymentFilterSeller = urlPayee;
+        if (urlGateway) paymentFilterGateway = urlGateway;
+
         buildTabs();
         renderInventoryForm();
         loadSellersAndCatalog();
+
+        if (urlTab && urlTab !== 'catalog') {
+            setTimeout(function() { switchTab(urlTab); }, 100);
+        }
     })();
     </script>
 </body>

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -611,8 +611,8 @@
                 sellerRow.appendChild(document.createTextNode('Seller: '));
                 var sellerLink = el('a', {
                     className: 'seller-link',
-                    href: 'profileChecker.html?address=' + sellerAddr,
-                    target: '_blank'
+                    href: '#',
+                    onClick: (function(a) { return function(e) { e.preventDefault(); filterCatalogBySeller(a); }; })(sellerAddr)
                 }, truncAddr(sellerAddr));
                 sellerRow.appendChild(sellerLink);
                 card.appendChild(sellerRow);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -397,6 +397,7 @@
     var sellersList = [];
     var catalogCursor = null;
     var catalogItems = [];
+    var catalogFilterSeller = null; // when set, catalog shows only this seller
     var currentTab = 'catalog';
     var authToken = null;
     var authAddress = null;
@@ -507,7 +508,10 @@
             catalogCursor = null;
         }
 
-        var avatarParams = sellersList.map(function(s) {
+        var sellers = catalogFilterSeller
+            ? [{seller: catalogFilterSeller}]
+            : sellersList;
+        var avatarParams = sellers.map(function(s) {
             return 'avatars=' + encodeURIComponent(s.seller || s.address || s);
         }).join('&');
 
@@ -531,8 +535,37 @@
         }
     }
 
+    function filterCatalogBySeller(addr) {
+        catalogFilterSeller = addr;
+        switchTab('catalog');
+        loadCatalog(true);
+    }
+
+    function clearCatalogFilter() {
+        catalogFilterSeller = null;
+        loadCatalog(true);
+    }
+
     function renderCatalog() {
         var container = clearEl('catalogContent');
+
+        // Show filter banner if filtering
+        if (catalogFilterSeller) {
+            var banner = el('div', {style: 'display:flex;align-items:center;gap:8px;padding:8px 12px;background:#dbeafe;border-radius:6px;margin-bottom:12px;font-size:0.9rem;'});
+            banner.appendChild(el('i', {className: 'fas fa-filter', style: 'color:#1e40af;'}));
+            var info = sellerInfoCache[catalogFilterSeller.toLowerCase()];
+            var label = info && info.name ? info.name : truncAddr(catalogFilterSeller);
+            banner.appendChild(document.createTextNode('Filtered by seller: ' + label));
+            var clearBtn = el('button', {
+                className: 'btn btn-sm btn-outline',
+                style: 'margin-left:auto;',
+                onClick: clearCatalogFilter
+            });
+            clearBtn.appendChild(el('i', {className: 'fas fa-xmark', style: 'margin-right:4px;'}));
+            clearBtn.appendChild(document.createTextNode('Clear'));
+            banner.appendChild(clearBtn);
+            container.appendChild(banner);
+        }
 
         if (!catalogItems.length) {
             container.appendChild(el('div', {className: 'empty-state'}, 'No catalog items found.'));
@@ -665,32 +698,29 @@
             var actCell = el('td');
             row.appendChild(actCell);
 
+            // Actions: view products (filter catalog) + gnosisscan
+            var productsBtn = el('button', {
+                className: 'btn btn-sm btn-outline',
+                style: 'display:inline-flex;align-items:center;gap:4px;margin-right:6px;',
+                onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(addr)
+            });
+            productsBtn.appendChild(el('i', {className: 'fas fa-boxes-stacked'}));
+            productsBtn.appendChild(document.createTextNode(' Products'));
+            actCell.appendChild(productsBtn);
+
+            var scanBtn = el('a', {
+                className: 'btn btn-sm btn-outline',
+                href: 'https://gnosisscan.io/address/' + addr,
+                target: '_blank',
+                style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
+            });
+            scanBtn.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square'}));
+            scanBtn.appendChild(document.createTextNode(' Gnosisscan'));
+            actCell.appendChild(scanBtn);
+
             enrichSeller(addr).then(function(info) {
                 infoCell.textContent = '';
                 renderSellerInfo(infoCell, info, addr);
-
-                // Actions: always show on-chain link, conditionally show CID history
-                var onChainBtn = el('a', {
-                    className: 'btn btn-sm btn-outline',
-                    href: 'profileChecker.html?address=' + addr,
-                    target: '_blank',
-                    style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;margin-right:6px;'
-                });
-                onChainBtn.appendChild(el('i', {className: 'fas fa-link'}));
-                onChainBtn.appendChild(document.createTextNode(' On-chain'));
-                actCell.appendChild(onChainBtn);
-
-                if (info.hasCidHistory) {
-                    var cidBtn = el('a', {
-                        className: 'btn btn-sm btn-outline',
-                        href: 'profileHistory.html?address=' + addr,
-                        target: '_blank',
-                        style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
-                    });
-                    cidBtn.appendChild(el('i', {className: 'fas fa-clock-rotate-left'}));
-                    cidBtn.appendChild(document.createTextNode(' CID History'));
-                    actCell.appendChild(cidBtn);
-                }
             });
 
             tbody.appendChild(row);
@@ -707,7 +737,7 @@
         var key = address.toLowerCase();
         if (sellerInfoCache[key]) return sellerInfoCache[key];
 
-        var info = { name: null, type: null, hasCidHistory: false };
+        var info = { name: null, type: null };
 
         // Profile name from pinning service
         try {
@@ -752,15 +782,6 @@
             }
         } catch (e) {}
 
-        // CID history availability (quick check)
-        try {
-            var histRes = await fetch('https://profiles.staging.aboutcircles.com/avatar/' + key + '/history?limit=1&offset=0');
-            if (histRes.ok) {
-                var histData = await histRes.json();
-                var entries = Array.isArray(histData) ? histData : (histData.history || []);
-                info.hasCidHistory = entries.length > 0;
-            }
-        } catch (e) {}
 
         sellerInfoCache[key] = info;
         return info;

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -6,7 +6,20 @@
     <title>Marketplace Explorer</title>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
-    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+    <!-- ethers.js loaded lazily when Orders tab needs wallet connection -->
+    <script>
+    var ethersLoaded = false;
+    function loadEthers() {
+        if (ethersLoaded) return Promise.resolve();
+        return new Promise(function(resolve, reject) {
+            var s = document.createElement('script');
+            s.src = 'https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js';
+            s.onload = function() { ethersLoaded = true; resolve(); };
+            s.onerror = reject;
+            document.head.appendChild(s);
+        });
+    }
+    </script>
     <style>
         :root {
             --primary: #191568;
@@ -425,9 +438,7 @@
 
         buildTabs();
         renderInventoryForm();
-        // Delay initial load slightly — Brave Shields can block fetches during
-        // synchronous script execution but allows them after a microtask
-        setTimeout(function() { loadSellersAndCatalog(); }, 0);
+        loadSellersAndCatalog();
     })();
 
     // ─── DOM helper ──────────────────────────────────────────────────
@@ -831,6 +842,7 @@
             return;
         }
         try {
+            await loadEthers();
             provider = new ethers.providers.Web3Provider(window.ethereum);
             await provider.send('eth_requestAccounts', []);
             signer = provider.getSigner();

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -541,6 +541,18 @@
         }
     }
 
+    function scrollToSeller(addr) {
+        switchTab('sellers');
+        setTimeout(function() {
+            var card = document.getElementById('seller-' + addr.toLowerCase());
+            if (card) {
+                card.scrollIntoView({behavior: 'smooth', block: 'center'});
+                card.style.boxShadow = '0 0 0 3px var(--accent)';
+                setTimeout(function() { card.style.boxShadow = ''; }, 2000);
+            }
+        }, 50);
+    }
+
     function filterCatalogBySeller(addr) {
         catalogFilterSeller = addr;
         switchTab('catalog');
@@ -629,7 +641,7 @@
                 var sellerLink = el('a', {
                     className: 'seller-link',
                     href: '#',
-                    onClick: (function(a) { return function(e) { e.preventDefault(); filterCatalogBySeller(a); }; })(sellerAddr)
+                    onClick: (function(a) { return function(e) { e.preventDefault(); scrollToSeller(a); }; })(sellerAddr)
                 }, truncAddr(sellerAddr));
                 sellerRow.appendChild(sellerLink);
                 card.appendChild(sellerRow);
@@ -652,7 +664,17 @@
 
             var sku = p.sku || item.sku || '';
             if (sku) {
-                card.appendChild(el('div', {className: 'meta'}, 'SKU: ' + sku));
+                var skuRow = el('div', {className: 'meta', style: 'display:flex;align-items:center;gap:6px;'});
+                skuRow.appendChild(document.createTextNode('SKU: ' + sku));
+                if (sellerAddr) {
+                    var stockBtn = el('button', {className: 'btn btn-sm btn-outline',
+                        style: 'font-size:0.75rem;padding:2px 8px;margin-left:auto;',
+                        onClick: (function(s, a) { return function() { checkInventoryFor(a, s); }; })(sku, sellerAddr)});
+                    stockBtn.appendChild(el('i', {className: 'fas fa-warehouse', style: 'margin-right:3px;'}));
+                    stockBtn.appendChild(document.createTextNode('Stock'));
+                    skuRow.appendChild(stockBtn);
+                }
+                card.appendChild(skuRow);
             }
 
             grid.appendChild(card);
@@ -671,7 +693,7 @@
         }
     }
 
-    // ─── Sellers table ───────────────────────────────────────────────
+    // ─── Sellers (card layout) ──────────────────────────────────────
     function renderSellersTable() {
         var container = clearEl('sellersContent');
 
@@ -680,80 +702,140 @@
             return;
         }
 
-        var table = el('table');
-        var thead = el('thead');
-        var hr = el('tr');
-        ['Address', 'Chain', 'Profile', 'Actions'].forEach(function(h) {
-            hr.appendChild(el('th', {}, h));
-        });
-        thead.appendChild(hr);
-        table.appendChild(thead);
+        var grid = el('div', {className: 'card-grid'});
 
-        var tbody = el('tbody');
         sellersList.forEach(function(seller) {
             var addr = seller.seller || seller.address || String(seller);
             var chain = seller.chainId || '100';
-            var row = el('tr');
+            var card = el('div', {className: 'product-card', id: 'seller-' + addr.toLowerCase()});
 
-            // Address
-            var addrCell = el('td', {className: 'address-cell'});
-            addrCell.appendChild(document.createTextNode(truncAddr(addr) + ' '));
+            // Header: name + type badge (async)
+            var nameRow = el('div', {style: 'display:flex;align-items:center;gap:8px;margin-bottom:4px;'});
+            var nameEl = el('h3', {style: 'margin:0;'}, 'Loading...');
+            nameRow.appendChild(nameEl);
+            card.appendChild(nameRow);
+
+            // Address row
+            var addrRow = el('div', {className: 'meta', style: 'font-family:monospace;display:flex;align-items:center;gap:4px;'});
+            addrRow.appendChild(document.createTextNode(truncAddr(addr)));
             var cpBtn = el('button', {className: 'copy-btn', title: 'Copy address',
                 onClick: function() { copyText(addr); }});
             cpBtn.appendChild(el('i', {className: 'fas fa-copy'}));
-            addrCell.appendChild(cpBtn);
-            row.appendChild(addrCell);
+            addrRow.appendChild(cpBtn);
+            addrRow.appendChild(document.createTextNode(' \u00B7 Chain ' + chain));
+            card.appendChild(addrRow);
 
-            // Chain
-            row.appendChild(el('td', {}, String(chain)));
+            // Gateways (async — populated after allGateways loads)
+            var gwRow = el('div', {className: 'meta', style: 'margin-top:6px;'}, '');
+            gwRow.id = 'gw-' + addr.toLowerCase();
+            card.appendChild(gwRow);
 
-            // Profile + type (async enriched)
-            var infoCell = el('td', {}, 'Loading...');
-            row.appendChild(infoCell);
+            // Actions row
+            var actions = el('div', {style: 'display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;'});
+            var btnStyle = 'display:inline-flex;align-items:center;gap:4px;font-size:0.8rem;padding:4px 10px;';
 
-            // Actions (async — links depend on enrichment)
-            var actCell = el('td');
-            row.appendChild(actCell);
-
-            // Actions: view products (filter catalog) + gnosisscan
-            var productsBtn = el('button', {
-                className: 'btn btn-sm btn-outline',
-                style: 'display:inline-flex;align-items:center;gap:4px;margin-right:6px;',
-                onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(addr)
-            });
+            var productsBtn = el('button', {className: 'btn btn-sm btn-outline', style: btnStyle,
+                onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(addr)});
             productsBtn.appendChild(el('i', {className: 'fas fa-boxes-stacked'}));
             productsBtn.appendChild(document.createTextNode(' Products'));
-            actCell.appendChild(productsBtn);
+            actions.appendChild(productsBtn);
 
-            var payBtn = el('button', {
-                className: 'btn btn-sm btn-outline',
-                style: 'display:inline-flex;align-items:center;gap:4px;margin-right:6px;',
-                onClick: (function(a) { return function() { filterPaymentsBySeller(a); }; })(addr)
-            });
+            var payBtn = el('button', {className: 'btn btn-sm btn-outline', style: btnStyle,
+                onClick: (function(a) { return function() { filterPaymentsBySeller(a); }; })(addr)});
             payBtn.appendChild(el('i', {className: 'fas fa-credit-card'}));
             payBtn.appendChild(document.createTextNode(' Payments'));
-            actCell.appendChild(payBtn);
+            actions.appendChild(payBtn);
 
-            var scanBtn = el('a', {
-                className: 'btn btn-sm btn-outline',
-                href: 'https://gnosisscan.io/address/' + addr,
-                target: '_blank',
-                style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
-            });
+            var scanBtn = el('a', {className: 'btn btn-sm btn-outline',
+                href: 'https://gnosisscan.io/address/' + addr, target: '_blank',
+                style: 'text-decoration:none;' + btnStyle});
             scanBtn.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square'}));
             scanBtn.appendChild(document.createTextNode(' Gnosisscan'));
-            actCell.appendChild(scanBtn);
+            actions.appendChild(scanBtn);
 
-            enrichSeller(addr).then(function(info) {
-                infoCell.textContent = '';
-                renderSellerInfo(infoCell, info, addr);
-            });
+            card.appendChild(actions);
 
-            tbody.appendChild(row);
+            // Async enrich name + type
+            (function(ne, addr) {
+                enrichSeller(addr).then(function(info) {
+                    ne.textContent = info.name || truncAddr(addr);
+                    if (info.type) {
+                        var badge = el('span', {
+                            style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;margin-left:6px;' +
+                                (info.type === 'human' ? 'background:#dcfce7;color:#166534;' :
+                                 info.type === 'organization' ? 'background:#dbeafe;color:#1e40af;' :
+                                 info.type === 'group' ? 'background:#e0e7ff;color:#3730a3;' :
+                                 'background:#f3f4f6;color:#374151;')
+                        }, info.type);
+                        ne.appendChild(badge);
+                    }
+                });
+            })(nameEl, addr);
+
+            grid.appendChild(card);
         });
 
-        table.appendChild(tbody);
-        container.appendChild(table);
+        container.appendChild(grid);
+
+        // Populate gateway info after gateways are loaded
+        loadGatewaysForSellers();
+    }
+
+    async function loadGatewaysForSellers() {
+        // Ensure gateways are loaded
+        if (!Object.keys(allGateways).length) {
+            try {
+                var gwResult = await rpcQuery('CrcV2_PaymentGateway', 'GatewayCreated',
+                    ['owner', 'gateway', 'blockNumber', 'timestamp'], [], 200);
+                (gwResult.rows || []).forEach(function(r) {
+                    allGateways[r[1].toLowerCase()] = { owner: r[0], gateway: r[1], block: r[2], created: r[3] };
+                });
+            } catch (e) { return; }
+        }
+
+        // Group gateways by owner
+        var byOwner = {};
+        Object.values(allGateways).forEach(function(gw) {
+            var key = gw.owner.toLowerCase();
+            if (!byOwner[key]) byOwner[key] = [];
+            byOwner[key].push(gw);
+        });
+
+        // Render into each seller card
+        sellersList.forEach(function(seller) {
+            var addr = (seller.seller || seller.address || String(seller)).toLowerCase();
+            var gwRow = document.getElementById('gw-' + addr);
+            if (!gwRow) return;
+
+            var gws = byOwner[addr] || [];
+            if (!gws.length) {
+                gwRow.appendChild(el('span', {style: 'color:var(--text-muted);'}, 'No payment gateway'));
+                return;
+            }
+
+            gwRow.appendChild(el('i', {className: 'fas fa-landmark', style: 'margin-right:4px;color:var(--primary);'}));
+            gwRow.appendChild(document.createTextNode(gws.length + ' gateway' + (gws.length > 1 ? 's' : '') + ': '));
+
+            gws.forEach(function(gw, i) {
+                if (i > 0) gwRow.appendChild(document.createTextNode(', '));
+                var gwLink = el('a', {href: '#', className: 'seller-link', style: 'font-family:monospace;font-size:0.8rem;',
+                    onClick: (function(g) { return function(e) {
+                        e.preventDefault();
+                        // Filter payments by this specific gateway
+                        paymentFilterSeller = null;
+                        paymentFilterGateway = g;
+                        paymentsLoaded = false;
+                        switchTab('payments');
+                        loadPayments();
+                    }; })(gw.gateway)
+                }, truncAddr(gw.gateway));
+                gwRow.appendChild(gwLink);
+                var cp = el('button', {className: 'copy-btn', title: 'Copy gateway address',
+                    onClick: function() { copyText(gw.gateway); }});
+                cp.appendChild(el('i', {className: 'fas fa-copy', style: 'font-size:0.7rem;'}));
+                gwRow.appendChild(cp);
+            });
+        });
     }
 
     // Seller info cache: { address: { name, type, hasCidHistory } }
@@ -839,6 +921,7 @@
     var allPayments = [];
     var allGateways = {};
     var paymentFilterSeller = null;
+    var paymentFilterGateway = null;
 
     function rpcQuery(namespace, table, columns, filter, limit, order) {
         var params = {Namespace: namespace, Table: table, Columns: columns, Filter: filter || [], Limit: limit || 50};
@@ -870,7 +953,7 @@
     }
 
     async function loadPayments() {
-        if (paymentsLoaded && !paymentFilterSeller) return;
+        if (paymentsLoaded && !paymentFilterSeller && !paymentFilterGateway) return;
         var container = document.getElementById('paymentsContent');
         showLoading(container);
 
@@ -884,10 +967,13 @@
                 });
             }
 
-            // Load payments
+            // Load payments with filters
             var filter = [];
             if (paymentFilterSeller) {
                 filter.push({Type:'FilterPredicate', FilterType:'Equals', Column:'payee', Value: paymentFilterSeller.toLowerCase()});
+            }
+            if (paymentFilterGateway) {
+                filter.push({Type:'FilterPredicate', FilterType:'Equals', Column:'gateway', Value: paymentFilterGateway.toLowerCase()});
             }
             var result = await rpcQuery('CrcV2_PaymentGateway', 'PaymentReceived',
                 ['payer', 'payee', 'gateway', 'amount', 'data', 'timestamp', 'transactionHash', 'blockNumber'],
@@ -895,7 +981,7 @@
                 [{Column:'blockNumber', SortOrder:'DESC'}]);
 
             allPayments = result.rows || [];
-            paymentsLoaded = !paymentFilterSeller;
+            paymentsLoaded = !paymentFilterSeller && !paymentFilterGateway;
             renderPayments();
         } catch (err) {
             showError(container, 'Failed to load payments: ' + err.message);
@@ -911,6 +997,7 @@
 
     function clearPaymentFilter() {
         paymentFilterSeller = null;
+        paymentFilterGateway = null;
         paymentsLoaded = false;
         loadPayments();
     }
@@ -940,12 +1027,16 @@
         container.appendChild(stats);
 
         // Filter banner
-        if (paymentFilterSeller) {
-            var banner = el('div', {style: 'display:flex;align-items:center;gap:8px;padding:8px 12px;background:#dbeafe;border-radius:6px;margin-bottom:12px;font-size:0.9rem;'});
+        if (paymentFilterSeller || paymentFilterGateway) {
+            var banner = el('div', {style: 'display:flex;align-items:center;gap:8px;padding:8px 12px;background:#dbeafe;border-radius:6px;margin-bottom:12px;font-size:0.9rem;flex-wrap:wrap;'});
             banner.appendChild(el('i', {className: 'fas fa-filter', style: 'color:#1e40af;'}));
-            var info = sellerInfoCache[paymentFilterSeller.toLowerCase()];
-            var label = info && info.name ? info.name : truncAddr(paymentFilterSeller);
-            banner.appendChild(document.createTextNode('Payments to: ' + label + ' '));
+            if (paymentFilterGateway) {
+                banner.appendChild(document.createTextNode('Gateway: ' + truncAddr(paymentFilterGateway) + ' '));
+            } else {
+                var info = sellerInfoCache[paymentFilterSeller.toLowerCase()];
+                var label = info && info.name ? info.name : truncAddr(paymentFilterSeller);
+                banner.appendChild(document.createTextNode('Payments to: ' + label + ' '));
+            }
             var jumpProducts = el('button', {className: 'btn btn-sm btn-outline', style: 'margin-left:8px;',
                 onClick: (function(a) { return function() { filterCatalogBySeller(a); }; })(paymentFilterSeller)});
             jumpProducts.appendChild(el('i', {className: 'fas fa-boxes-stacked', style: 'margin-right:4px;'}));
@@ -1100,6 +1191,17 @@
     function viewSellerPayments(addr) { filterPaymentsBySeller(addr); }
 
     // ─── Inventory ───────────────────────────────────────────────────
+    function checkInventoryFor(seller, sku) {
+        switchTab('inventory');
+        setTimeout(function() {
+            var sellerEl = document.getElementById('invSeller');
+            var skuEl = document.getElementById('invSku');
+            if (sellerEl) sellerEl.value = seller;
+            if (skuEl) skuEl.value = sku;
+            checkInventory();
+        }, 50);
+    }
+
     function renderInventoryForm() {
         var container = clearEl('inventoryContent');
 

--- a/profileChecker.html
+++ b/profileChecker.html
@@ -970,9 +970,17 @@
                                 getBotClassification(trustedAddr).then(botData => {
                                     if (botData) {
                                         if (botData.is_bot) {
-                                            botCell.innerHTML = `<span style="color: #cc0000;">Bot (${botData.category})</span>`;
+                                            const s = document.createElement('span');
+                                            s.style.color = '#cc0000';
+                                            s.textContent = 'Bot (' + (botData.category || 'unknown') + ')';
+                                            botCell.textContent = '';
+                                            botCell.appendChild(s);
                                         } else {
-                                            botCell.innerHTML = `<span style="color: #006600;">Human</span>`;
+                                            const s = document.createElement('span');
+                                            s.style.color = '#006600';
+                                            s.textContent = 'Human';
+                                            botCell.textContent = '';
+                                            botCell.appendChild(s);
                                         }
                                     } else {
                                         botCell.textContent = 'Unknown';
@@ -1226,14 +1234,9 @@
                             ownerLink.href = 'profileChecker.html?address=' + t.tokenOwner;
                             ownerLink.className = 'address-link';
                             ownerLink.textContent = truncateAddress(t.tokenOwner);
+                            ownerLink.dataset.addr = t.tokenOwner;
                             ownerCell.appendChild(ownerLink);
                             row.appendChild(ownerCell);
-                            getProfileName(t.tokenOwner).then(name => {
-                                if (name && name !== 'No name' && name !== 'None' && name !== 'Fetch error') {
-                                    ownerLink.textContent = name;
-                                    ownerLink.title = t.tokenOwner;
-                                }
-                            });
 
                             // Type
                             const typeCell = document.createElement('td');
@@ -1261,6 +1264,18 @@
                         });
                         table.appendChild(tbody);
                         tableContainer.appendChild(table);
+
+                        // Batch-fetch names for token owners
+                        const ownerAddrs = filtered.map(t => t.tokenOwner);
+                        batchGetProfileNames(ownerAddrs).then(nameMap => {
+                            tbody.querySelectorAll('a[data-addr]').forEach(link => {
+                                const addr = link.dataset.addr;
+                                if (addr && nameMap[addr] && nameMap[addr] !== 'No name') {
+                                    link.textContent = nameMap[addr];
+                                    link.title = addr;
+                                }
+                            });
+                        });
 
                         const countLabel = document.createElement('p');
                         countLabel.className = 'info';

--- a/profileChecker.html
+++ b/profileChecker.html
@@ -638,7 +638,7 @@
                     const mainSCRC = erc20Map[inputAddress.toLowerCase()]?.demurragedERC20; // sCRC (inflationary/static)
                     let summaryHtml = '';
                     summaryHtml += `<div class="info"><strong>Address:</strong> <span id="main-user-name">Loading...</span> <a href="profileHistory.html?address=${inputAddress}" style="font-size:0.85rem;color:#191568;margin-left:8px;" title="View CID History">CID History &rarr;</a></div>`;
-                    summaryHtml += `<div class="info" style="display:flex;gap:8px;margin-top:6px;"><a href="#trustSection" style="font-size:0.85rem;color:#191568;">Trust Connections &darr;</a><a href="#tokenBalancesSection" style="font-size:0.85rem;color:#191568;">Token Balances &darr;</a></div>`;
+                    summaryHtml += `<div id="topSection" class="info" style="display:flex;gap:8px;margin-top:6px;"><a href="#trustSection" style="font-size:0.85rem;color:#191568;">Trust Connections &darr;</a><a href="#tokenBalancesSection" style="font-size:0.85rem;color:#191568;">Token Balances &darr;</a></div>`;
                     summaryHtml += `<div class="info"><strong>Price:</strong> $<span id="main-user-price">...</span> / CRC</div>`;
                     // V1 Info
                     summaryHtml += `<div class="info"><strong>[V1] Status:</strong> ${v1Data.isHuman ? 'human' : (v1Data.isOrg ? 'org' : 'none')}</div>`;
@@ -758,6 +758,21 @@
                     if (trustedAddressesData.length > 0) {
                         const trustAnchor = document.createElement("div");
                         trustAnchor.id = "trustSection";
+                        trustAnchor.style.cssText = 'display:flex;align-items:center;gap:8px;margin-top:16px;';
+                        const trustLabel = document.createElement("strong");
+                        trustLabel.textContent = "Trust Connections";
+                        trustLabel.style.fontSize = "1.1rem";
+                        trustAnchor.appendChild(trustLabel);
+                        const trustTopLink = document.createElement("a");
+                        trustTopLink.href = "#topSection";
+                        trustTopLink.style.cssText = "font-size:0.8rem;color:#191568;";
+                        trustTopLink.textContent = "\u2191 Top";
+                        trustAnchor.appendChild(trustTopLink);
+                        const trustTokenLink = document.createElement("a");
+                        trustTokenLink.href = "#tokenBalancesSection";
+                        trustTokenLink.style.cssText = "font-size:0.8rem;color:#191568;";
+                        trustTokenLink.textContent = "Token Balances \u2193";
+                        trustAnchor.appendChild(trustTokenLink);
                         resultDiv.appendChild(trustAnchor);
                         const table = document.createElement("table");
                         const thead = document.createElement("thead");
@@ -1077,6 +1092,11 @@
                 const heading = document.createElement('h3');
                 heading.style.cssText = 'margin-top:24px;font-size:1.1rem;';
                 heading.textContent = 'Token Balances ';
+                const topLink = document.createElement('a');
+                topLink.href = '#topSection';
+                topLink.style.cssText = 'font-size:0.8rem;color:#191568;margin-left:8px;font-weight:400;';
+                topLink.textContent = '\u2191 Top';
+                heading.appendChild(topLink);
                 const spinner = document.createElement('span');
                 spinner.className = 'loader';
                 spinner.id = 'tokenLoader';

--- a/profileChecker.html
+++ b/profileChecker.html
@@ -638,6 +638,7 @@
                     const mainSCRC = erc20Map[inputAddress.toLowerCase()]?.demurragedERC20; // sCRC (inflationary/static)
                     let summaryHtml = '';
                     summaryHtml += `<div class="info"><strong>Address:</strong> <span id="main-user-name">Loading...</span> <a href="profileHistory.html?address=${inputAddress}" style="font-size:0.85rem;color:#191568;margin-left:8px;" title="View CID History">CID History &rarr;</a></div>`;
+                    summaryHtml += `<div class="info" style="display:flex;gap:8px;margin-top:6px;"><a href="#trustSection" style="font-size:0.85rem;color:#191568;">Trust Connections &darr;</a><a href="#tokenBalancesSection" style="font-size:0.85rem;color:#191568;">Token Balances &darr;</a></div>`;
                     summaryHtml += `<div class="info"><strong>Price:</strong> $<span id="main-user-price">...</span> / CRC</div>`;
                     // V1 Info
                     summaryHtml += `<div class="info"><strong>[V1] Status:</strong> ${v1Data.isHuman ? 'human' : (v1Data.isOrg ? 'org' : 'none')}</div>`;
@@ -755,6 +756,9 @@
                     // For large lists (>100), skip per-row async calls (price, bot, balancer)
                     const isLargeList = trustedAddressesData.length > 100;
                     if (trustedAddressesData.length > 0) {
+                        const trustAnchor = document.createElement("div");
+                        trustAnchor.id = "trustSection";
+                        resultDiv.appendChild(trustAnchor);
                         const table = document.createElement("table");
                         const thead = document.createElement("thead");
                         const headerRow = document.createElement("tr");
@@ -1069,6 +1073,7 @@
 
             async function fetchTokenBalances(address, container) {
                 const section = document.createElement('div');
+                section.id = 'tokenBalancesSection';
                 const heading = document.createElement('h3');
                 heading.style.cssText = 'margin-top:24px;font-size:1.1rem;';
                 heading.textContent = 'Token Balances ';

--- a/profileChecker.html
+++ b/profileChecker.html
@@ -204,6 +204,62 @@
             strong {
                 font-weight: 600;
             }
+            /* Token Balances Section */
+            .token-summary {
+                display: flex;
+                gap: 12px;
+                flex-wrap: wrap;
+                margin: 20px 0 12px;
+            }
+            .token-summary-card {
+                background: #fff;
+                border: 1px solid #e5e3fb;
+                border-radius: 8px;
+                padding: 10px 14px;
+                min-width: 110px;
+            }
+            .token-summary-card .label {
+                font-size: 0.78rem;
+                color: #666;
+                margin-bottom: 2px;
+            }
+            .token-summary-card .value {
+                font-size: 1.15rem;
+                font-weight: 700;
+                color: #191568;
+            }
+            .token-filters {
+                display: flex;
+                gap: 6px;
+                margin-bottom: 10px;
+                flex-wrap: wrap;
+            }
+            .token-filter-btn {
+                padding: 4px 12px;
+                border: 1px solid #e5e3fb;
+                border-radius: 16px;
+                background: transparent;
+                font-family: inherit;
+                font-size: 0.82rem;
+                cursor: pointer;
+                transition: all 0.2s;
+                color: #191568;
+            }
+            .token-filter-btn:hover { background: #f0eef9; }
+            .token-filter-btn.active { background: #191568; color: #fff; border-color: #191568; }
+            .type-badge {
+                display: inline-block;
+                font-size: 0.72rem;
+                padding: 1px 6px;
+                border-radius: 8px;
+                font-weight: 600;
+            }
+            .type-badge.human { background: #dcfce7; color: #166534; }
+            .type-badge.group { background: #e0e7ff; color: #3730a3; }
+            .type-badge.wrapped { background: #dbeafe; color: #1e40af; }
+            .type-badge.v1 { background: #f3f4f6; color: #374151; }
+            th.sortable { cursor: pointer; user-select: none; }
+            th.sortable:hover { background: #d5d2f5; }
             .loader {
                 border: 4px solid #f3f3f3;
                 border-top: 4px solid #191568;
@@ -963,9 +1019,236 @@
                         });
                     }
 
+                    // ─── Token Balances Section ──────────────────────
+                    fetchTokenBalances(inputAddress, resultDiv);
+
                 } catch (error) {
                     console.error("Error in checkAddress:", error);
                     resultDiv.innerHTML = `<p style='color:red;'>Error: ${error.message || 'Failed to fetch data.'}</p>`;
+                }
+            }
+
+            /********************************************************
+             *  Token Balances (via circles_getTokenBalances RPC)
+             ********************************************************/
+            function classifyToken(t) {
+                if ((t.tokenType || '').startsWith('CrcV1')) return 'v1';
+                if (t.isWrapped) return 'wrapped';
+                if (t.isGroup) return 'group';
+                return 'personal';
+            }
+
+            function typeBadgeEl(t) {
+                const cls = classifyToken(t);
+                const labels = { personal: 'human', group: 'group', wrapped: t.isInflationary ? 'wrapped-infl' : 'wrapped-dem', v1: 'v1' };
+                const cssCls = cls === 'personal' ? 'human' : cls;
+                const span = document.createElement('span');
+                span.className = 'type-badge ' + cssCls;
+                span.textContent = labels[cls] || cls;
+                return span;
+            }
+
+            function fmtBal(n) {
+                if (n == null || isNaN(n)) return '0';
+                return Number(n).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+            }
+
+            function mkSummaryCard(label, value) {
+                const card = document.createElement('div');
+                card.className = 'token-summary-card';
+                const lbl = document.createElement('div');
+                lbl.className = 'label';
+                lbl.textContent = label;
+                const val = document.createElement('div');
+                val.className = 'value';
+                val.textContent = value;
+                card.appendChild(lbl);
+                card.appendChild(val);
+                return card;
+            }
+
+            async function fetchTokenBalances(address, container) {
+                const section = document.createElement('div');
+                const heading = document.createElement('h3');
+                heading.style.cssText = 'margin-top:24px;font-size:1.1rem;';
+                heading.textContent = 'Token Balances ';
+                const spinner = document.createElement('span');
+                spinner.className = 'loader';
+                spinner.id = 'tokenLoader';
+                heading.appendChild(spinner);
+                section.appendChild(heading);
+                container.appendChild(section);
+
+                try {
+                    const res = await fetch('https://rpc.aboutcircles.com/', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({jsonrpc:'2.0', id:2, method:'circles_getTokenBalances', params:[address]})
+                    });
+                    const rpcData = await res.json();
+                    const tokens = rpcData.result || [];
+                    const loader = document.getElementById('tokenLoader');
+                    if (loader) loader.remove();
+
+                    if (!tokens.length) {
+                        const p = document.createElement('p');
+                        p.className = 'info';
+                        p.style.color = '#666';
+                        p.textContent = 'No token balances found.';
+                        section.appendChild(p);
+                        return;
+                    }
+
+                    // Summaries
+                    let totalCrc = 0, wrappedCrc = 0, groupCrc = 0, groupCount = 0, v1Crc = 0;
+                    tokens.forEach(t => {
+                        const crc = Number(t.crc) || 0;
+                        totalCrc += crc;
+                        if (t.isWrapped) wrappedCrc += crc;
+                        if (t.isGroup) { groupCrc += crc; groupCount++; }
+                        if ((t.tokenType || '').startsWith('CrcV1')) v1Crc += crc;
+                    });
+
+                    const summaryDiv = document.createElement('div');
+                    summaryDiv.className = 'token-summary';
+                    summaryDiv.appendChild(mkSummaryCard('Total CRC', fmtBal(totalCrc)));
+                    summaryDiv.appendChild(mkSummaryCard('Wrapped ERC20', fmtBal(wrappedCrc)));
+                    summaryDiv.appendChild(mkSummaryCard('Group Tokens', groupCount + ' (' + fmtBal(groupCrc) + ')'));
+                    summaryDiv.appendChild(mkSummaryCard('V1', fmtBal(v1Crc)));
+                    section.appendChild(summaryDiv);
+
+                    // Filter buttons
+                    const filterDiv = document.createElement('div');
+                    filterDiv.className = 'token-filters';
+                    let currentFilter = 'all';
+                    const filterNames = ['all', 'personal', 'group', 'wrapped', 'v1'];
+
+                    function renderFilters() {
+                        filterDiv.textContent = '';
+                        filterNames.forEach(f => {
+                            const btn = document.createElement('button');
+                            btn.className = 'token-filter-btn' + (currentFilter === f ? ' active' : '');
+                            btn.textContent = f.charAt(0).toUpperCase() + f.slice(1);
+                            btn.onclick = () => { currentFilter = f; renderFilters(); renderTokenTable(); };
+                            filterDiv.appendChild(btn);
+                        });
+                    }
+                    renderFilters();
+                    section.appendChild(filterDiv);
+
+                    const tableContainer = document.createElement('div');
+                    tableContainer.id = 'tokenTableContainer';
+                    section.appendChild(tableContainer);
+
+                    let sortCol = 'crc';
+                    let sortAsc = false;
+
+                    function renderTokenTable() {
+                        let filtered = currentFilter === 'all' ? tokens : tokens.filter(t => classifyToken(t) === currentFilter);
+                        filtered.sort((a, b) => {
+                            const va = sortCol === 'crc' ? (Number(a.crc)||0) : (Number(a.staticCircles)||0);
+                            const vb = sortCol === 'crc' ? (Number(b.crc)||0) : (Number(b.staticCircles)||0);
+                            return sortAsc ? va - vb : vb - va;
+                        });
+
+                        tableContainer.textContent = '';
+                        if (!filtered.length) {
+                            const p = document.createElement('p');
+                            p.className = 'info';
+                            p.style.color = '#666';
+                            p.textContent = 'No tokens match this filter.';
+                            tableContainer.appendChild(p);
+                            return;
+                        }
+
+                        const table = document.createElement('table');
+                        const thead = document.createElement('thead');
+                        const headerRow = document.createElement('tr');
+                        const cols = [
+                            {key:'owner', label:'Token Owner', sort:false},
+                            {key:'type', label:'Type', sort:false},
+                            {key:'crc', label:'Balance (CRC)', sort:true},
+                            {key:'static', label:'Balance (static)', sort:true},
+                            {key:'wrapped', label:'Wrapped', sort:false}
+                        ];
+                        cols.forEach(col => {
+                            const th = document.createElement('th');
+                            th.textContent = col.label + (col.sort && sortCol === col.key ? (sortAsc ? ' ▲' : ' ▼') : '');
+                            if (col.sort) {
+                                th.className = 'sortable';
+                                th.onclick = () => {
+                                    if (sortCol === col.key) sortAsc = !sortAsc;
+                                    else { sortCol = col.key; sortAsc = false; }
+                                    renderTokenTable();
+                                };
+                            }
+                            headerRow.appendChild(th);
+                        });
+                        thead.appendChild(headerRow);
+                        table.appendChild(thead);
+
+                        const tbody = document.createElement('tbody');
+                        filtered.forEach(t => {
+                            const row = document.createElement('tr');
+
+                            // Owner
+                            const ownerCell = document.createElement('td');
+                            const ownerLink = document.createElement('a');
+                            ownerLink.href = 'profileChecker.html?address=' + t.tokenOwner;
+                            ownerLink.className = 'address-link';
+                            ownerLink.textContent = truncateAddress(t.tokenOwner);
+                            ownerCell.appendChild(ownerLink);
+                            row.appendChild(ownerCell);
+                            getProfileName(t.tokenOwner).then(name => {
+                                if (name && name !== 'No name' && name !== 'None' && name !== 'Fetch error') {
+                                    ownerLink.textContent = name;
+                                    ownerLink.title = t.tokenOwner;
+                                }
+                            });
+
+                            // Type
+                            const typeCell = document.createElement('td');
+                            typeCell.appendChild(typeBadgeEl(t));
+                            row.appendChild(typeCell);
+
+                            // CRC
+                            const crcCell = document.createElement('td');
+                            crcCell.textContent = fmtBal(t.crc);
+                            crcCell.style.fontWeight = '500';
+                            row.appendChild(crcCell);
+
+                            // Static
+                            const staticCell = document.createElement('td');
+                            staticCell.textContent = fmtBal(t.staticCircles);
+                            row.appendChild(staticCell);
+
+                            // Wrapped
+                            const wrappedCell = document.createElement('td');
+                            wrappedCell.textContent = t.isWrapped ? '✓' : '–';
+                            wrappedCell.style.textAlign = 'center';
+                            row.appendChild(wrappedCell);
+
+                            tbody.appendChild(row);
+                        });
+                        table.appendChild(tbody);
+                        tableContainer.appendChild(table);
+
+                        const countLabel = document.createElement('p');
+                        countLabel.className = 'info';
+                        countLabel.style.color = '#666';
+                        countLabel.textContent = 'Showing ' + filtered.length + ' of ' + tokens.length + ' tokens';
+                        tableContainer.appendChild(countLabel);
+                    }
+                    renderTokenTable();
+                } catch (err) {
+                    console.error('Token balances failed:', err);
+                    const loader = document.getElementById('tokenLoader');
+                    if (loader) loader.remove();
+                    const p = document.createElement('p');
+                    p.className = 'info';
+                    p.style.color = 'red';
+                    p.textContent = 'Failed to load token balances: ' + err.message;
+                    section.appendChild(p);
                 }
             }
 

--- a/profileChecker.html
+++ b/profileChecker.html
@@ -637,8 +637,7 @@
                     // and demurragedERC20 is actually the static/inflationary sCRC token.
                     const mainSCRC = erc20Map[inputAddress.toLowerCase()]?.demurragedERC20; // sCRC (inflationary/static)
                     let summaryHtml = '';
-                    summaryHtml += `<div class="info"><strong>Address:</strong> <span id="main-user-name">Loading...</span> <a href="profileHistory.html?address=${inputAddress}" style="font-size:0.85rem;color:#191568;margin-left:8px;" title="View CID History">CID History &rarr;</a></div>`;
-                    summaryHtml += `<div id="topSection" class="info" style="display:flex;gap:8px;margin-top:6px;"><a href="#trustSection" style="font-size:0.85rem;color:#191568;">Trust Connections &darr;</a><a href="#tokenBalancesSection" style="font-size:0.85rem;color:#191568;">Token Balances &darr;</a></div>`;
+                    summaryHtml += `<div id="topSection" class="info" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;"><strong>Address:</strong> <span id="main-user-name">Loading...</span><span style="margin-left:auto;display:flex;gap:8px;font-size:0.85rem;"><a href="profileHistory.html?address=${inputAddress}" style="color:#191568;">CID History &rarr;</a><a href="#trustSection" style="color:#191568;">Trust &darr;</a><a href="#tokenBalancesSection" style="color:#191568;">Balances &darr;</a></span></div>`;
                     summaryHtml += `<div class="info"><strong>Price:</strong> $<span id="main-user-price">...</span> / CRC</div>`;
                     // V1 Info
                     summaryHtml += `<div class="info"><strong>[V1] Status:</strong> ${v1Data.isHuman ? 'human' : (v1Data.isOrg ? 'org' : 'none')}</div>`;
@@ -1092,10 +1091,15 @@
                 const heading = document.createElement('h3');
                 heading.style.cssText = 'margin-top:24px;font-size:1.1rem;';
                 heading.textContent = 'Token Balances ';
+                const trustLink2 = document.createElement('a');
+                trustLink2.href = '#trustSection';
+                trustLink2.style.cssText = 'font-size:0.8rem;color:#191568;margin-left:8px;font-weight:400;';
+                trustLink2.textContent = 'Trust \u2191';
+                heading.appendChild(trustLink2);
                 const topLink = document.createElement('a');
                 topLink.href = '#topSection';
                 topLink.style.cssText = 'font-size:0.8rem;color:#191568;margin-left:8px;font-weight:400;';
-                topLink.textContent = '\u2191 Top';
+                topLink.textContent = 'Top \u2191';
                 heading.appendChild(topLink);
                 const spinner = document.createElement('span');
                 spinner.className = 'loader';

--- a/profileChecker.html
+++ b/profileChecker.html
@@ -581,7 +581,7 @@
                     // and demurragedERC20 is actually the static/inflationary sCRC token.
                     const mainSCRC = erc20Map[inputAddress.toLowerCase()]?.demurragedERC20; // sCRC (inflationary/static)
                     let summaryHtml = '';
-                    summaryHtml += `<div class="info"><strong>Address:</strong> <span id="main-user-name">Loading...</span></div>`;
+                    summaryHtml += `<div class="info"><strong>Address:</strong> <span id="main-user-name">Loading...</span> <a href="profileHistory.html?address=${inputAddress}" style="font-size:0.85rem;color:#191568;margin-left:8px;" title="View CID History">CID History &rarr;</a></div>`;
                     summaryHtml += `<div class="info"><strong>Price:</strong> $<span id="main-user-price">...</span> / CRC</div>`;
                     // V1 Info
                     summaryHtml += `<div class="info"><strong>[V1] Status:</strong> ${v1Data.isHuman ? 'human' : (v1Data.isOrg ? 'org' : 'none')}</div>`;

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -487,9 +487,18 @@
     }
 
     async function fetchCidContent(cid) {
+        // Try /get first (shaped profile response), fall back to /raw/:cid
+        // which fetches from IPFS gateway for GC'd CIDs and re-caches them
         var res = await fetch(apiBase + '/get?cid=' + encodeURIComponent(cid));
-        if (!res.ok) throw new Error('CID content fetch failed: ' + res.status);
-        return res.json();
+        if (res.ok) return res.json();
+
+        var rawRes = await fetch(apiBase + '/raw/' + encodeURIComponent(cid));
+        if (rawRes.ok) {
+            var data = await rawRes.json();
+            data._source = 'raw';
+            return data;
+        }
+        throw new Error('CID unavailable (/get: ' + res.status + ', /raw: ' + rawRes.status + ')');
     }
 
     // ─── Main flow ───────────────────────────────────────────────────
@@ -756,7 +765,14 @@
     function renderJsonWithPreviews(obj) {
         var body = document.getElementById('inspectBody');
         body.textContent = '';
-        // Walk keys, render each as a row; if value is base64 image, show preview
+        // Show IPFS gateway fallback notice
+        if (obj && obj._source === 'raw') {
+            var notice = el('div', {style: 'padding:6px 10px;background:#fef3c7;border-radius:4px;font-size:0.82rem;color:#92400e;margin-bottom:8px;'});
+            notice.appendChild(el('i', {className: 'fas fa-triangle-exclamation', style: 'margin-right:6px;'}));
+            notice.appendChild(document.createTextNode('Fetched via /raw fallback (CID was GC\'d, re-fetched from IPFS gateway)'));
+            body.appendChild(notice);
+            delete obj._source;
+        }
         if (typeof obj !== 'object' || obj === null) {
             body.appendChild(el('pre', {}, JSON.stringify(obj, null, 2)));
             return;

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -1065,13 +1065,11 @@
         for (var i = 0; i < str.length; i++) {
             var c = B58_ALPHABET.indexOf(str[i]);
             if (c < 0) throw new Error('Invalid base58 char: ' + str[i]);
-            for (var j = 0; j < bytes.length; j++) bytes[j] *= 58;
-            bytes[0] += c;
-            var carry = 0;
+            var carry = c;
             for (var j = 0; j < bytes.length; j++) {
-                bytes[j] += carry;
-                carry = (bytes[j] >> 8);
-                bytes[j] &= 0xff;
+                carry += bytes[j] * 58;
+                bytes[j] = carry & 0xff;
+                carry >>= 8;
             }
             while (carry) { bytes.push(carry & 0xff); carry >>= 8; }
         }

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -386,8 +386,17 @@
         <div>
             <h1><i class="fas fa-clock-rotate-left" style="margin-right: 8px;"></i>Profile CID History</h1>
         </div>
-        <div class="header-links">
-            <a href="index.html"><i class="fas fa-home"></i> Tools</a>
+        <div style="display:flex;align-items:center;gap:12px;">
+            <div id="walletBar" style="display:none;font-size:0.85rem;padding:4px 12px;background:rgba(255,255,255,0.1);border-radius:20px;display:none;align-items:center;gap:6px;">
+                <span style="width:8px;height:8px;border-radius:50%;background:var(--success);"></span>
+                <span id="walletAddr"></span>
+                <button id="walletDisconnect" style="background:none;border:none;color:rgba(255,255,255,0.6);cursor:pointer;font-size:0.8rem;padding:2px 4px;" title="Disconnect">
+                    <i class="fas fa-xmark"></i>
+                </button>
+            </div>
+            <div class="header-links">
+                <a href="index.html"><i class="fas fa-home"></i> Tools</a>
+            </div>
         </div>
     </header>
 
@@ -1076,30 +1085,64 @@
         return '0x' + Array.from(digest).map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
     }
 
+    var connectedSigner = null;
+    var connectedAddr = null;
+
+    function showWallet(addr) {
+        connectedAddr = addr;
+        var bar = document.getElementById('walletBar');
+        bar.style.display = 'flex';
+        document.getElementById('walletAddr').textContent = addr.slice(0,6) + '...' + addr.slice(-4);
+    }
+
+    function hideWallet() {
+        connectedSigner = null;
+        connectedAddr = null;
+        document.getElementById('walletBar').style.display = 'none';
+    }
+
+    document.getElementById('walletDisconnect').addEventListener('click', hideWallet);
+
+    async function connectWallet() {
+        try { await loadEthers(); } catch (e) { throw new Error('Failed to load ethers.js — CDN may be blocked'); }
+        if (typeof ethers === 'undefined') throw new Error('ethers.js failed to initialize');
+        if (!window.ethereum) throw new Error('No wallet detected. Install MetaMask or similar.');
+
+        var provider = new ethers.providers.Web3Provider(window.ethereum);
+        await provider.send('eth_requestAccounts', []);
+        connectedSigner = provider.getSigner();
+        var addr = await connectedSigner.getAddress();
+        showWallet(addr);
+        return addr;
+    }
+
     async function restoreProfile(cid) {
         if (!cid || !currentAddress) return;
-        if (!confirm('Restore profile to CID:\n' + cid + '\n\nThis will update your on-chain profile metadata. You must be the owner of address ' + currentAddress + '.'))
-            return;
 
         var restoreBtn = document.getElementById('restoreBtn');
-        if (restoreBtn) { restoreBtn.disabled = true; restoreBtn.textContent = 'Connecting...'; }
 
         try {
-            try { await loadEthers(); } catch (e) { throw new Error('Failed to load ethers.js — CDN may be blocked by your browser'); }
-            if (typeof ethers === 'undefined') throw new Error('ethers.js failed to initialize');
-            if (!window.ethereum) throw new Error('No wallet found. Install MetaMask or similar.');
+            // Step 1: Connect wallet if not connected
+            if (!connectedAddr) {
+                if (restoreBtn) { restoreBtn.disabled = true; restoreBtn.textContent = 'Connect wallet...'; }
+                await connectWallet();
+            }
 
-            var provider = new ethers.providers.Web3Provider(window.ethereum);
-            await provider.send('eth_requestAccounts', []);
-            var signer = provider.getSigner();
-            var signerAddr = await signer.getAddress();
+            // Step 2: Verify address match
+            if (connectedAddr.toLowerCase() !== currentAddress.toLowerCase()) {
+                alert('Wrong wallet connected!\n\nConnected: ' + connectedAddr + '\nNeeded: ' + currentAddress + '\n\nPlease switch to the correct account in your wallet and try again.');
+                if (restoreBtn) { restoreBtn.disabled = false; restoreBtn.textContent = 'Restore'; }
+                return;
+            }
 
-            if (signerAddr.toLowerCase() !== currentAddress.toLowerCase())
-                throw new Error('Connected wallet (' + signerAddr.slice(0,6) + '...) does not match profile address (' + currentAddress.slice(0,6) + '...).');
+            // Step 3: Confirm
+            if (!confirm('Restore profile to CID:\n' + cid + '\n\nThis sends a transaction from ' + connectedAddr.slice(0,6) + '...' + connectedAddr.slice(-4)))
+                return;
 
+            // Step 4: Send tx
             if (restoreBtn) restoreBtn.textContent = 'Sending tx...';
             var bytes32 = cidV0ToBytes32(cid);
-            var contract = new ethers.Contract(NAME_REGISTRY, NAME_REGISTRY_ABI, signer);
+            var contract = new ethers.Contract(NAME_REGISTRY, NAME_REGISTRY_ABI, connectedSigner);
             var tx = await contract.updateMetadataDigest(bytes32);
 
             if (restoreBtn) restoreBtn.textContent = 'Confirming...';

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -1085,7 +1085,8 @@
         if (restoreBtn) { restoreBtn.disabled = true; restoreBtn.textContent = 'Connecting...'; }
 
         try {
-            await loadEthers();
+            try { await loadEthers(); } catch (e) { throw new Error('Failed to load ethers.js — CDN may be blocked by your browser'); }
+            if (typeof ethers === 'undefined') throw new Error('ethers.js failed to initialize');
             if (!window.ethereum) throw new Error('No wallet found. Install MetaMask or similar.');
 
             var provider = new ethers.providers.Web3Provider(window.ethereum);
@@ -1108,9 +1109,9 @@
             setTimeout(function() { checkHistory(); }, 2000);
         } catch (err) {
             console.error('Restore failed:', err);
+            var msg = err.reason || err.message || String(err);
             if (restoreBtn) { restoreBtn.disabled = false; restoreBtn.textContent = 'Restore'; }
-            var body = document.getElementById('inspectBody');
-            if (body) body.appendChild(el('div', {className: 'error-msg', style: 'margin-top:8px;'}, 'Restore failed: ' + (err.reason || err.message)));
+            alert('Restore failed: ' + msg);
         }
     }
     </script>

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -365,8 +365,8 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
-                <option value="https://profiles.staging.aboutcircles.com">Staging</option>
                 <option value="https://profiles.aboutcircles.com">Production</option>
+                <option value="https://profiles.staging.aboutcircles.com">Staging</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>
@@ -399,8 +399,7 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    const DEFAULT_API = 'https://profiles.staging.aboutcircles.com';
-    // prod subdomain (profiles.aboutcircles.com) not yet live; will migrate later
+    const DEFAULT_API = 'https://profiles.aboutcircles.com';
     const PAGE_SIZE = 50;
 
     let apiBase = DEFAULT_API;

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -209,35 +209,87 @@
             cursor: pointer;
         }
 
-        /* Detail panel */
-        .detail-panel {
+        /* Bottom inspect panel (fixed) */
+        .inspect-panel {
+            position: fixed;
+            bottom: 0; left: 0; right: 0;
+            height: 280px;
+            min-height: 100px;
+            max-height: 70vh;
             background: var(--card-bg);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            margin-top: 24px;
-            overflow: hidden;
+            border-top: 1px solid var(--border);
+            display: none;
+            flex-direction: column;
+            z-index: 50;
+            box-shadow: 0 -4px 20px rgba(0,0,0,0.1);
         }
-        .detail-header {
-            padding: 12px 16px;
+        .inspect-panel.visible { display: flex; }
+        .inspect-panel .resize-handle {
+            position: absolute;
+            left: 0; right: 0; top: 0;
+            height: 5px;
+            cursor: row-resize;
+            background: transparent;
+            z-index: 10;
+            transition: background 0.2s;
+        }
+        .inspect-panel .resize-handle:hover,
+        .inspect-panel .resize-handle.dragging { background: var(--accent); }
+        .inspect-header {
+            padding: 8px 16px;
             background: #f0eef9;
             font-weight: 600;
-            font-size: 0.95rem;
+            font-size: 0.9rem;
             display: flex;
             justify-content: space-between;
             align-items: center;
+            flex-shrink: 0;
+            gap: 8px;
         }
-        .detail-body {
-            padding: 16px;
-            max-height: 500px;
+        .inspect-header .header-left {
+            display: flex; align-items: center; gap: 8px;
+            min-width: 0; overflow: hidden;
+        }
+        .inspect-header .header-left span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .inspect-header .header-actions { display: flex; gap: 6px; flex-shrink: 0; }
+        .inspect-close {
+            background: none; border: none; cursor: pointer;
+            font-size: 1.1rem; color: var(--text-muted);
+            padding: 4px 6px; border-radius: 4px;
+            transition: background 0.2s;
+        }
+        .inspect-close:hover { background: #e5e3fb; color: var(--text); }
+        .inspect-body {
+            flex: 1;
             overflow: auto;
+            padding: 12px 16px;
         }
-        .detail-body pre {
+        .inspect-body pre {
             margin: 0;
             white-space: pre-wrap;
             word-break: break-word;
             font-size: 0.85rem;
             line-height: 1.5;
         }
+        /* Base64 image preview */
+        .b64-row {
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+            margin: 4px 0;
+        }
+        .b64-row pre { flex: 1; min-width: 0; }
+        .b64-preview {
+            flex-shrink: 0;
+            max-width: 120px;
+            max-height: 120px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            object-fit: contain;
+            background: #f9f9f9;
+        }
+        /* Adjust main content to not hide behind panel */
+        body.panel-open .container { padding-bottom: 300px; }
 
         /* Diff view */
         .diff-container {
@@ -323,7 +375,21 @@
 
         <div id="profileSection" style="display:none;"></div>
         <div id="timelineSection"></div>
-        <div id="detailSection"></div>
+    </div>
+
+    <!-- Fixed bottom inspect panel -->
+    <div class="inspect-panel" id="inspectPanel">
+        <div class="resize-handle" id="resizeHandle"></div>
+        <div class="inspect-header">
+            <div class="header-left">
+                <span id="inspectTitle">CID Content</span>
+            </div>
+            <div class="header-actions">
+                <button class="copy-btn" id="inspectCopyBtn" title="Copy CID"><i class="fas fa-copy"></i></button>
+                <button class="inspect-close" id="inspectCloseBtn" title="Close"><i class="fas fa-xmark"></i></button>
+            </div>
+        </div>
+        <div class="inspect-body" id="inspectBody"></div>
     </div>
 
     <script>
@@ -450,12 +516,10 @@
 
         var profileSection = document.getElementById('profileSection');
         var timelineSection = document.getElementById('timelineSection');
-        var detailSection = document.getElementById('detailSection');
-
+        closePanel();
         profileSection.style.display = 'none';
         profileSection.textContent = '';
         timelineSection.textContent = '';
-        detailSection.textContent = '';
 
         try {
             var [profile, history] = await Promise.allSettled([
@@ -652,31 +716,100 @@
         }
     }
 
-    async function inspectCid(cid, label) {
-        var detailSection = document.getElementById('detailSection');
-        detailSection.textContent = '';
+    // ─── Bottom panel helpers ────────────────────────────────────────
+    var currentPanelCid = '';
 
-        var panel = el('div', {className: 'detail-panel'});
-        var header = el('div', {className: 'detail-header'});
-        header.appendChild(el('span', {}, (label || 'CID') + ': ' + cid));
-        var copyHdr = el('button', {className: 'copy-btn', title: 'Copy full CID',
-            onClick: function() { copyText(cid); }});
-        copyHdr.appendChild(el('i', {className: 'fas fa-copy'}));
-        copyHdr.appendChild(document.createTextNode(' Copy'));
-        header.appendChild(copyHdr);
-        panel.appendChild(header);
+    function openPanel(title, cid) {
+        currentPanelCid = cid || '';
+        document.getElementById('inspectTitle').textContent = title;
+        document.getElementById('inspectPanel').classList.add('visible');
+        document.body.classList.add('panel-open');
+    }
 
-        var body = el('div', {className: 'detail-body'});
+    function closePanel() {
+        document.getElementById('inspectPanel').classList.remove('visible');
+        document.body.classList.remove('panel-open');
+        document.getElementById('inspectBody').textContent = '';
+    }
+
+    function panelLoading() {
+        var body = document.getElementById('inspectBody');
+        body.textContent = '';
         body.appendChild(el('span', {className: 'loader'}));
         body.appendChild(document.createTextNode(' Loading...'));
-        panel.appendChild(body);
-        detailSection.appendChild(panel);
+    }
 
+    // Base64 image detection regex
+    var B64_IMG_RE = /^data:image\/[a-z+]+;base64,/;
+
+    function renderJsonWithPreviews(obj) {
+        var body = document.getElementById('inspectBody');
+        body.textContent = '';
+        // Walk keys, render each as a row; if value is base64 image, show preview
+        if (typeof obj !== 'object' || obj === null) {
+            body.appendChild(el('pre', {}, JSON.stringify(obj, null, 2)));
+            return;
+        }
+        Object.keys(obj).forEach(function(key) {
+            var val = obj[key];
+            var strVal = typeof val === 'string' ? val : JSON.stringify(val, null, 2);
+
+            if (typeof val === 'string' && B64_IMG_RE.test(val)) {
+                // Base64 image — show preview alongside truncated value
+                var row = el('div', {className: 'b64-row'});
+                var truncated = val.slice(0, 60) + '... (' + Math.round(val.length / 1024) + ' KB)';
+                row.appendChild(el('pre', {}, '"' + key + '": "' + truncated + '"'));
+                var img = el('img', {className: 'b64-preview', alt: key});
+                img.src = val;
+                row.appendChild(img);
+                body.appendChild(row);
+            } else {
+                body.appendChild(el('pre', {}, '"' + key + '": ' + strVal));
+            }
+        });
+    }
+
+    // Close + copy wiring
+    document.getElementById('inspectCloseBtn').addEventListener('click', closePanel);
+    document.getElementById('inspectCopyBtn').addEventListener('click', function() { copyText(currentPanelCid); });
+
+    // ─── Resize drag ─────────────────────────────────────────────────
+    (function initResize() {
+        var handle = document.getElementById('resizeHandle');
+        var panel = document.getElementById('inspectPanel');
+        var dragging = false;
+
+        handle.addEventListener('mousedown', function(e) {
+            e.preventDefault();
+            dragging = true;
+            handle.classList.add('dragging');
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
+
+        function onMove(e) {
+            if (!dragging) return;
+            var newH = window.innerHeight - e.clientY;
+            newH = Math.max(100, Math.min(newH, window.innerHeight * 0.7));
+            panel.style.height = newH + 'px';
+        }
+        function onUp() {
+            dragging = false;
+            handle.classList.remove('dragging');
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onUp);
+        }
+    })();
+
+    // ─── Inspect / View ──────────────────────────────────────────────
+    async function inspectCid(cid, label) {
+        openPanel((label || 'CID') + ': ' + cid, cid);
+        panelLoading();
         try {
             var content = await fetchCidContent(cid);
-            body.textContent = '';
-            body.appendChild(el('pre', {}, JSON.stringify(content, null, 2)));
+            renderJsonWithPreviews(content);
         } catch (err) {
+            var body = document.getElementById('inspectBody');
             body.textContent = '';
             body.appendChild(el('div', {className: 'error-msg'}, 'Failed to load: ' + err.message));
         }
@@ -688,33 +821,16 @@
 
         var entry = historyEntries[idx];
         var cid = entry.cid || entry.cidV0 || '';
-        var detailSection = document.getElementById('detailSection');
-        detailSection.textContent = '';
-
-        var panel = el('div', {className: 'detail-panel'});
-        var header = el('div', {className: 'detail-header'});
-        header.appendChild(el('span', {}, 'Profile at CID: ' + truncateCid(cid)));
-        var copyHdr = el('button', {className: 'copy-btn', title: 'Copy full CID',
-            onClick: function() { copyText(cid); }});
-        copyHdr.appendChild(el('i', {className: 'fas fa-copy'}));
-        copyHdr.appendChild(document.createTextNode(' Copy CID'));
-        header.appendChild(copyHdr);
-        panel.appendChild(header);
-
-        var body = el('div', {className: 'detail-body'});
-        body.appendChild(el('span', {className: 'loader'}));
-        body.appendChild(document.createTextNode(' Loading...'));
-        panel.appendChild(body);
-        detailSection.appendChild(panel);
-
+        var label = idx === 0 ? 'Current' : '#' + (idx + 1);
+        openPanel(label + ' — ' + cid, cid);
+        panelLoading();
         try {
             var content = await fetchCidContent(cid);
-            body.textContent = '';
-            var pre = el('pre', {}, JSON.stringify(content, null, 2));
-            body.appendChild(pre);
+            renderJsonWithPreviews(content);
         } catch (err) {
+            var body = document.getElementById('inspectBody');
             body.textContent = '';
-            body.appendChild(el('div', {className: 'error-msg'}, 'Failed to load CID content: ' + err.message));
+            body.appendChild(el('div', {className: 'error-msg'}, 'Failed: ' + err.message));
         }
     }
 
@@ -749,18 +865,8 @@
         var cidA = entryA.cid || entryA.cidV0;
         var cidB = entryB.cid || entryB.cidV0;
 
-        var detailSection = document.getElementById('detailSection');
-        detailSection.textContent = '';
-
-        var panel = el('div', {className: 'detail-panel'});
-        var header = el('div', {className: 'detail-header'});
-        header.appendChild(el('span', {}, 'Diff: #' + (idxA + 1) + ' vs #' + (idxB + 1)));
-        panel.appendChild(header);
-        var body = el('div', {className: 'detail-body'});
-        body.appendChild(el('span', {className: 'loader'}));
-        body.appendChild(document.createTextNode(' Loading both CIDs...'));
-        panel.appendChild(body);
-        detailSection.appendChild(panel);
+        openPanel('Diff: #' + (idxA + 1) + ' vs #' + (idxB + 1), '');
+        panelLoading();
 
         try {
             var [contentA, contentB] = await Promise.all([
@@ -769,94 +875,72 @@
             ]);
             renderDiff(contentA, contentB, cidA, cidB, idxA, idxB);
         } catch (err) {
+            var body = document.getElementById('inspectBody');
             body.textContent = '';
             body.appendChild(el('div', {className: 'error-msg'}, 'Diff failed: ' + err.message));
         }
     }
 
     function renderDiff(objA, objB, cidA, cidB, idxA, idxB) {
-        // Recursive diff: walks nested objects/arrays and emits per-leaf lines
         function diffLines(a, b, prefix) {
             var lines = [];
-            if (a === b || JSON.stringify(a) === JSON.stringify(b)) {
-                // identical subtree — emit collapsed
-                lines.push({cls: 'diff-unchanged', textA: prefix + JSON.stringify(a), textB: prefix + JSON.stringify(b)});
+            var strA = JSON.stringify(a), strB = JSON.stringify(b);
+            if (a === b || strA === strB) {
+                // Skip base64 image data in unchanged lines for readability
+                var display = (typeof a === 'string' && B64_IMG_RE.test(a))
+                    ? '"' + a.slice(0, 40) + '..." (image)'
+                    : strA;
+                lines.push({cls: 'diff-unchanged', textA: prefix + display, textB: prefix + display});
                 return lines;
             }
             var aIsObj = a !== null && typeof a === 'object' && !Array.isArray(a);
             var bIsObj = b !== null && typeof b === 'object' && !Array.isArray(b);
             if (aIsObj && bIsObj) {
-                var keys = Array.from(new Set(Object.keys(a).concat(Object.keys(b)))).sort();
-                keys.forEach(function(k) {
-                    var childPrefix = prefix ? prefix + '.' + k : k;
-                    if (!(k in a)) {
-                        lines.push({cls: 'diff-added', textA: '', textB: childPrefix + ': ' + JSON.stringify(b[k])});
-                    } else if (!(k in b)) {
-                        lines.push({cls: 'diff-removed', textA: childPrefix + ': ' + JSON.stringify(a[k]), textB: ''});
-                    } else {
-                        lines = lines.concat(diffLines(a[k], b[k], childPrefix));
-                    }
+                Array.from(new Set(Object.keys(a).concat(Object.keys(b)))).sort().forEach(function(k) {
+                    var cp = prefix ? prefix + '.' + k : k;
+                    if (!(k in a)) lines.push({cls: 'diff-added', textA: '', textB: cp + ': ' + JSON.stringify(b[k])});
+                    else if (!(k in b)) lines.push({cls: 'diff-removed', textA: cp + ': ' + JSON.stringify(a[k]), textB: ''});
+                    else lines = lines.concat(diffLines(a[k], b[k], cp));
                 });
                 return lines;
             }
-            var aIsArr = Array.isArray(a);
-            var bIsArr = Array.isArray(b);
-            if (aIsArr && bIsArr) {
-                var maxLen = Math.max(a.length, b.length);
-                for (var i = 0; i < maxLen; i++) {
-                    var idxPrefix = prefix + '[' + i + ']';
-                    if (i >= a.length) {
-                        lines.push({cls: 'diff-added', textA: '', textB: idxPrefix + ': ' + JSON.stringify(b[i])});
-                    } else if (i >= b.length) {
-                        lines.push({cls: 'diff-removed', textA: idxPrefix + ': ' + JSON.stringify(a[i]), textB: ''});
-                    } else {
-                        lines = lines.concat(diffLines(a[i], b[i], idxPrefix));
-                    }
+            if (Array.isArray(a) && Array.isArray(b)) {
+                for (var i = 0; i < Math.max(a.length, b.length); i++) {
+                    var ip = prefix + '[' + i + ']';
+                    if (i >= a.length) lines.push({cls: 'diff-added', textA: '', textB: ip + ': ' + JSON.stringify(b[i])});
+                    else if (i >= b.length) lines.push({cls: 'diff-removed', textA: ip + ': ' + JSON.stringify(a[i]), textB: ''});
+                    else lines = lines.concat(diffLines(a[i], b[i], ip));
                 }
                 return lines;
             }
-            // Leaf difference
-            lines.push({
-                cls: 'diff-changed',
-                textA: prefix + ': ' + JSON.stringify(a),
-                textB: prefix + ': ' + JSON.stringify(b)
-            });
+            lines.push({cls: 'diff-changed', textA: prefix + ': ' + strA, textB: prefix + ': ' + strB});
             return lines;
         }
 
         var lines = diffLines(objA || {}, objB || {}, '');
+        var body = document.getElementById('inspectBody');
+        body.textContent = '';
 
-        var detailSection = document.getElementById('detailSection');
-        detailSection.textContent = '';
-
-        var panel = el('div', {className: 'detail-panel'});
-        var header = el('div', {className: 'detail-header'});
-        header.appendChild(el('span', {}, 'Diff: #' + (idxA + 1) + ' vs #' + (idxB + 1)));
-        panel.appendChild(header);
-
-        var body = el('div', {className: 'detail-body'});
         var container = el('div', {className: 'diff-container'});
-
         var sideA = el('div', {className: 'diff-side'});
         sideA.appendChild(el('h3', {}, '#' + (idxA + 1) + ' \u2014 ' + truncateCid(cidA)));
         var sideB = el('div', {className: 'diff-side'});
         sideB.appendChild(el('h3', {}, '#' + (idxB + 1) + ' \u2014 ' + truncateCid(cidB)));
 
         lines.forEach(function(l) {
-            var lineA = el('div', {className: 'diff-line ' + (l.cls === 'diff-changed' ? 'diff-removed' : l.cls === 'diff-added' ? '' : l.cls)});
-            lineA.textContent = l.textA || '\u00A0';
-            sideA.appendChild(lineA);
-
-            var lineB = el('div', {className: 'diff-line ' + (l.cls === 'diff-changed' ? 'diff-added' : l.cls === 'diff-removed' ? '' : l.cls)});
-            lineB.textContent = l.textB || '\u00A0';
-            sideB.appendChild(lineB);
+            var clsA = l.cls === 'diff-changed' ? 'diff-removed' : l.cls === 'diff-added' ? '' : l.cls;
+            var clsB = l.cls === 'diff-changed' ? 'diff-added' : l.cls === 'diff-removed' ? '' : l.cls;
+            var la = el('div', {className: 'diff-line ' + clsA});
+            la.textContent = l.textA || '\u00A0';
+            sideA.appendChild(la);
+            var lb = el('div', {className: 'diff-line ' + clsB});
+            lb.textContent = l.textB || '\u00A0';
+            sideB.appendChild(lb);
         });
 
         container.appendChild(sideA);
         container.appendChild(sideB);
         body.appendChild(container);
-        panel.appendChild(body);
-        detailSection.appendChild(panel);
     }
     </script>
 </body>

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -1055,7 +1055,7 @@
     }
 
     // ─── Profile Restore (rollback CID on-chain) ─────────────────────
-    var NAME_REGISTRY = '0xA27566fD89162cC3D40Cb59c87AAaA49B85F3474';
+    var NAME_REGISTRY = '0xA27566fD89162cC3D40Cb59c87AAaA49B85F3474'; // Gnosis Chain (100)
     var NAME_REGISTRY_ABI = ['function updateMetadataDigest(bytes32 _metadataDigest)'];
 
     // Base58 decoder (CIDv0 uses base58btc)
@@ -1110,6 +1110,8 @@
 
         var provider = new ethers.providers.Web3Provider(window.ethereum);
         await provider.send('eth_requestAccounts', []);
+        var network = await provider.getNetwork();
+        if (network.chainId !== 100) throw new Error('Please switch to Gnosis Chain (chain ID 100). Currently on chain ' + network.chainId);
         connectedSigner = provider.getSigner();
         var addr = await connectedSigner.getAddress();
         showWallet(addr);

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -404,8 +404,8 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
-                <option value="https://profiles.aboutcircles.com">Production</option>
                 <option value="https://profiles.staging.aboutcircles.com">Staging</option>
+                <option value="https://profiles.aboutcircles.com">Production</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>
@@ -438,7 +438,7 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    const DEFAULT_API = 'https://profiles.aboutcircles.com';
+    const DEFAULT_API = 'https://profiles.staging.aboutcircles.com';
     const PAGE_SIZE = 50;
 
     let apiBase = DEFAULT_API;

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -302,6 +302,7 @@
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
                 <option value="https://profiles.staging.aboutcircles.com">Staging</option>
+                <option value="https://profiles.aboutcircles.com">Production</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -1,0 +1,806 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Profile CID History</title>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
+    <style>
+        :root {
+            --primary: #191568;
+            --accent: #ff491b;
+            --bg: #fff7f5;
+            --card-bg: #ffffff;
+            --border: #e5e3fb;
+            --text: #191568;
+            --text-muted: #666;
+            --success: #22c55e;
+            --error: #ef4444;
+        }
+        * { box-sizing: border-box; margin: 0; }
+        body {
+            font-family: "DM Sans", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.5;
+        }
+        header {
+            background: var(--primary);
+            color: #fff;
+            padding: 15px 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 15px;
+            flex-wrap: wrap;
+        }
+        header h1 { margin: 0; font-weight: 600; font-size: 1.3rem; }
+        .header-links a {
+            color: rgba(255,255,255,0.8);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+        .header-links a:hover { color: #fff; }
+        .container {
+            max-width: 960px;
+            margin: 30px auto;
+            padding: 0 20px;
+        }
+        .input-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        .input-row input {
+            flex: 1;
+            padding: 10px 14px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-size: 1rem;
+            font-family: inherit;
+        }
+        .input-row input:focus { outline: 2px solid var(--primary); border-color: transparent; }
+        .btn {
+            padding: 10px 20px;
+            background: var(--primary);
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 1rem;
+            font-weight: 600;
+            font-family: inherit;
+            white-space: nowrap;
+            transition: background 0.2s;
+        }
+        .btn:hover { background: #251b9f; }
+        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .btn-sm {
+            padding: 5px 12px;
+            font-size: 0.85rem;
+            border-radius: 4px;
+        }
+        .btn-outline {
+            background: transparent;
+            color: var(--primary);
+            border: 1px solid var(--border);
+        }
+        .btn-outline:hover { background: var(--border); }
+        .btn-accent { background: var(--accent); }
+        .btn-accent:hover { background: #e0400f; }
+
+        .api-config {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-bottom: 15px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .api-config code {
+            background: #f0eef9;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.8rem;
+        }
+
+        /* Current profile card */
+        .profile-card {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 16px;
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            margin-bottom: 24px;
+        }
+        .profile-avatar {
+            width: 64px;
+            height: 64px;
+            border-radius: 50%;
+            object-fit: cover;
+            background: var(--border);
+            flex-shrink: 0;
+        }
+        .profile-info h2 { font-size: 1.15rem; margin-bottom: 4px; }
+        .profile-info .cid-line {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            font-family: monospace;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        /* Timeline */
+        .timeline { position: relative; padding-left: 28px; margin-top: 16px; }
+        .timeline::before {
+            content: '';
+            position: absolute;
+            left: 8px;
+            top: 8px;
+            bottom: 8px;
+            width: 2px;
+            background: var(--border);
+        }
+        .timeline-entry {
+            position: relative;
+            margin-bottom: 12px;
+            cursor: pointer;
+        }
+        .timeline-dot {
+            position: absolute;
+            left: -22px;
+            top: 10px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: #ccc;
+            border: 2px solid var(--bg);
+        }
+        .timeline-entry:first-child .timeline-dot { background: var(--success); }
+        .timeline-entry.selected .timeline-dot { background: var(--accent); }
+
+        .timeline-card {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 12px 14px;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .timeline-entry:hover .timeline-card { border-color: var(--primary); }
+        .timeline-entry.selected .timeline-card {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px rgba(255,73,27,0.15);
+        }
+        .timeline-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin-bottom: 6px;
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+        .timeline-cid {
+            font-family: monospace;
+            font-size: 0.82rem;
+            color: var(--text);
+            background: #f0eef9;
+            padding: 2px 8px;
+            border-radius: 3px;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .timeline-actions {
+            display: flex;
+            gap: 6px;
+            margin-top: 8px;
+        }
+        .diff-select {
+            width: 16px;
+            height: 16px;
+            accent-color: var(--primary);
+            cursor: pointer;
+        }
+
+        /* Detail panel */
+        .detail-panel {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            margin-top: 24px;
+            overflow: hidden;
+        }
+        .detail-header {
+            padding: 12px 16px;
+            background: #f0eef9;
+            font-weight: 600;
+            font-size: 0.95rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .detail-body {
+            padding: 16px;
+            max-height: 500px;
+            overflow: auto;
+        }
+        .detail-body pre {
+            margin: 0;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-size: 0.85rem;
+            line-height: 1.5;
+        }
+
+        /* Diff view */
+        .diff-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
+        .diff-side { min-width: 0; }
+        .diff-side h3 { font-size: 0.9rem; margin-bottom: 8px; color: var(--text-muted); }
+        .diff-line { font-size: 0.85rem; padding: 1px 4px; border-radius: 2px; font-family: monospace; }
+        .diff-added { background: #dcfce7; }
+        .diff-removed { background: #fee2e2; }
+        .diff-unchanged { color: var(--text-muted); }
+
+        /* Loading & error */
+        .loader {
+            border: 3px solid #f3f3f3;
+            border-top: 3px solid var(--primary);
+            border-radius: 50%;
+            width: 20px;
+            height: 20px;
+            animation: spin 0.8s linear infinite;
+            display: inline-block;
+            vertical-align: middle;
+            margin-left: 8px;
+        }
+        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+        .error-msg { color: var(--error); padding: 12px; background: #fef2f2; border-radius: 6px; margin: 10px 0; }
+        .empty-state { text-align: center; color: var(--text-muted); padding: 40px 20px; }
+
+        .load-more-row { text-align: center; margin: 16px 0; }
+        .copy-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            padding: 2px;
+            transition: color 0.2s;
+        }
+        .copy-btn:hover { color: var(--primary); }
+
+        @media (max-width: 600px) {
+            .diff-container { grid-template-columns: 1fr; }
+            .input-row { flex-direction: column; }
+        }
+    </style>
+    <script defer data-domain="aboutcircles.github.io/circlestools" src="https://plausible.io/js/script.js"></script>
+</head>
+<body>
+    <header>
+        <div>
+            <h1><i class="fas fa-clock-rotate-left" style="margin-right: 8px;"></i>Profile CID History</h1>
+        </div>
+        <div class="header-links">
+            <a href="index.html"><i class="fas fa-home"></i> Tools</a>
+        </div>
+    </header>
+
+    <div class="container">
+        <div class="api-config">
+            <i class="fas fa-server"></i>
+            API: <code id="apiUrlDisplay"></code>
+        </div>
+
+        <div class="input-row">
+            <input type="text" id="addressInput" placeholder="0x... Circles address" />
+            <button class="btn" id="checkBtn" onclick="checkHistory()">
+                <i class="fas fa-search"></i> Check
+            </button>
+        </div>
+
+        <div id="profileSection" style="display:none;"></div>
+        <div id="timelineSection"></div>
+        <div id="detailSection"></div>
+    </div>
+
+    <script>
+    // ─── Configuration ───────────────────────────────────────────────
+    const DEFAULT_API = 'https://rpc.aboutcircles.com/profiles';
+    const FALLBACK_API = 'https://staging.aboutcircles.com/profiles';
+    const PAGE_SIZE = 50;
+
+    let apiBase = DEFAULT_API;
+    let historyEntries = [];
+    let selectedEntry = null;
+    let diffSelections = [];   // max 2 CID indices for diffing
+    let currentAddress = null;
+    let offset = 0;
+    let hasMore = true;
+
+    // Allow override via ?pinningApi= or ?api= query param
+    (function initConfig() {
+        const params = new URLSearchParams(window.location.search);
+        const override = params.get('pinningApi') || params.get('api');
+        if (override) {
+            apiBase = override.replace(/\/+$/, '');
+        }
+        document.getElementById('apiUrlDisplay').textContent = apiBase;
+
+        const addr = params.get('address');
+        if (addr) {
+            document.getElementById('addressInput').value = addr;
+            setTimeout(function() { checkHistory(); }, 50);
+        }
+    })();
+
+    // ─── Utility ─────────────────────────────────────────────────────
+    function truncateCid(cid) {
+        if (!cid || cid.length < 16) return cid || '';
+        return cid.slice(0, 8) + '...' + cid.slice(-6);
+    }
+
+    function escapeHtml(s) {
+        var d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    function formatTimestamp(ts) {
+        var d = typeof ts === 'number' ? new Date(ts < 1e12 ? ts * 1000 : ts) : new Date(ts);
+        if (isNaN(d.getTime())) return String(ts);
+        return d.toLocaleString();
+    }
+
+    function copyText(text) {
+        navigator.clipboard.writeText(text);
+    }
+
+    function el(tag, attrs, children) {
+        var e = document.createElement(tag);
+        if (attrs) Object.entries(attrs).forEach(function([k,v]) {
+            if (k === 'className') e.className = v;
+            else if (k === 'textContent') e.textContent = v;
+            else if (k.startsWith('on')) e.addEventListener(k.slice(2).toLowerCase(), v);
+            else e.setAttribute(k, v);
+        });
+        if (children) {
+            if (typeof children === 'string') e.textContent = children;
+            else if (Array.isArray(children)) children.forEach(function(c) { if (c) e.appendChild(c); });
+            else e.appendChild(children);
+        }
+        return e;
+    }
+
+    // ─── API helpers ─────────────────────────────────────────────────
+    async function fetchCurrentProfile(address) {
+        var res = await fetch(apiBase + '/api/profile/' + address);
+        if (!res.ok) throw new Error('Profile fetch failed: ' + res.status);
+        return res.json();
+    }
+
+    async function fetchCidHistory(address, limit, off) {
+        var res = await fetch(apiBase + '/api/avatar/' + address + '/history?limit=' + limit + '&offset=' + off);
+        if (!res.ok) throw new Error('History fetch failed: ' + res.status);
+        return res.json();
+    }
+
+    async function fetchCidContent(cid) {
+        var res = await fetch(apiBase + '/api/get?cid=' + encodeURIComponent(cid));
+        if (!res.ok) throw new Error('CID content fetch failed: ' + res.status);
+        return res.json();
+    }
+
+    // ─── Main flow ───────────────────────────────────────────────────
+    async function checkHistory() {
+        var addr = document.getElementById('addressInput').value.trim();
+        if (!addr || !/^0x[0-9a-fA-F]{40}$/.test(addr)) {
+            var errDiv = document.getElementById('timelineSection');
+            errDiv.textContent = '';
+            var errMsg = el('div', {className: 'error-msg'}, 'Please enter a valid Ethereum address.');
+            errDiv.appendChild(errMsg);
+            return;
+        }
+
+        currentAddress = addr;
+        offset = 0;
+        historyEntries = [];
+        diffSelections = [];
+        selectedEntry = null;
+        hasMore = true;
+
+        window.history.replaceState(null, '', '?address=' + addr +
+            (apiBase !== DEFAULT_API ? '&pinningApi=' + encodeURIComponent(apiBase) : ''));
+
+        var btn = document.getElementById('checkBtn');
+        btn.disabled = true;
+        btn.textContent = '';
+        btn.appendChild(el('span', {className: 'loader'}));
+        btn.appendChild(document.createTextNode(' Loading...'));
+
+        var profileSection = document.getElementById('profileSection');
+        var timelineSection = document.getElementById('timelineSection');
+        var detailSection = document.getElementById('detailSection');
+
+        profileSection.style.display = 'none';
+        profileSection.textContent = '';
+        timelineSection.textContent = '';
+        detailSection.textContent = '';
+
+        try {
+            var [profile, history] = await Promise.allSettled([
+                fetchCurrentProfile(addr),
+                fetchCidHistory(addr, PAGE_SIZE, 0)
+            ]);
+
+            if (profile.status === 'fulfilled' && profile.value) {
+                renderProfileCard(profile.value, addr);
+            }
+
+            if (history.status === 'fulfilled') {
+                var entries = Array.isArray(history.value) ? history.value : (history.value.history || []);
+                historyEntries = entries;
+                hasMore = entries.length >= PAGE_SIZE;
+                offset = entries.length;
+                renderTimeline();
+            } else {
+                timelineSection.textContent = '';
+                timelineSection.appendChild(el('div', {className: 'error-msg'},
+                    'Failed to load CID history. The profile may not exist in the pinning service.'));
+            }
+        } catch (err) {
+            timelineSection.textContent = '';
+            timelineSection.appendChild(el('div', {className: 'error-msg'}, err.message));
+        } finally {
+            btn.disabled = false;
+            btn.textContent = '';
+            var icon = el('i', {className: 'fas fa-search'});
+            btn.appendChild(icon);
+            btn.appendChild(document.createTextNode(' Check'));
+        }
+    }
+
+    async function loadMore() {
+        if (!currentAddress || !hasMore) return;
+        try {
+            var result = await fetchCidHistory(currentAddress, PAGE_SIZE, offset);
+            var arr = Array.isArray(result) ? result : (result.history || []);
+            historyEntries = historyEntries.concat(arr);
+            hasMore = arr.length >= PAGE_SIZE;
+            offset += arr.length;
+            renderTimeline();
+        } catch (err) {
+            console.warn('Load more failed:', err);
+        }
+    }
+
+    // ─── Renderers (DOM-based) ───────────────────────────────────────
+    function renderProfileCard(profile, address) {
+        var section = document.getElementById('profileSection');
+        section.textContent = '';
+
+        var name = profile.name || profile.username || 'Unknown';
+        var avatarUrl = profile.previewImageUrl || profile.avatarUrl || '';
+        var cid = profile.cidV0 || profile.cid || 'N/A';
+
+        var card = el('div', {className: 'profile-card'});
+
+        // Avatar
+        if (avatarUrl) {
+            var img = el('img', {className: 'profile-avatar', alt: 'avatar'});
+            img.src = avatarUrl;
+            img.onerror = function() { this.style.display = 'none'; };
+            card.appendChild(img);
+        } else {
+            var placeholder = el('div', {className: 'profile-avatar',
+                style: 'display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:var(--text-muted);'});
+            placeholder.appendChild(el('i', {className: 'fas fa-user'}));
+            card.appendChild(placeholder);
+        }
+
+        var info = el('div', {className: 'profile-info'});
+        info.appendChild(el('h2', {}, name));
+
+        var cidLine = el('div', {className: 'cid-line'});
+        cidLine.appendChild(el('span', {}, 'CID: ' + truncateCid(cid)));
+        var copyBtn = el('button', {className: 'copy-btn', title: 'Copy CID',
+            onClick: function() { copyText(cid); }});
+        copyBtn.appendChild(el('i', {className: 'fas fa-copy'}));
+        cidLine.appendChild(copyBtn);
+        info.appendChild(cidLine);
+
+        var linkRow = el('div', {style: 'margin-top:6px;'});
+        var profileLink = el('a', {
+            href: 'profileChecker.html?address=' + address,
+            className: 'btn btn-sm btn-outline',
+            style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
+        });
+        profileLink.appendChild(el('i', {className: 'fas fa-user'}));
+        profileLink.appendChild(document.createTextNode(' On-chain Profile'));
+        linkRow.appendChild(profileLink);
+        info.appendChild(linkRow);
+
+        card.appendChild(info);
+        section.appendChild(card);
+        section.style.display = 'block';
+    }
+
+    function renderTimeline() {
+        var section = document.getElementById('timelineSection');
+        section.textContent = '';
+
+        if (!historyEntries.length) {
+            var empty = el('div', {className: 'empty-state'});
+            empty.appendChild(el('i', {className: 'fas fa-inbox', style: 'font-size:2rem;margin-bottom:8px;'}));
+            empty.appendChild(el('br'));
+            empty.appendChild(document.createTextNode('No CID history found for this address.'));
+            section.appendChild(empty);
+            return;
+        }
+
+        var heading = el('h3', {style: 'margin-bottom:12px;font-size:1rem;'},
+            'CID History (' + historyEntries.length + (hasMore ? '+' : '') + ' entries)');
+        section.appendChild(heading);
+
+        var btnRow = el('div', {style: 'margin-bottom:12px;'});
+        var diffBtn = el('button', {className: 'btn btn-sm btn-accent', id: 'diffBtn', disabled: 'true',
+            onClick: function() { showDiff(); }});
+        diffBtn.appendChild(el('i', {className: 'fas fa-code-compare'}));
+        diffBtn.appendChild(document.createTextNode(' Compare Selected (0/2)'));
+        btnRow.appendChild(diffBtn);
+        section.appendChild(btnRow);
+
+        var timeline = el('div', {className: 'timeline'});
+
+        historyEntries.forEach(function(entry, idx) {
+            var cid = entry.cid || entry.cidV0 || 'unknown';
+            var block = entry.blockNumber || entry.block || '';
+            var timestamp = entry.timestamp ? formatTimestamp(entry.timestamp) : '';
+            var isSelected = selectedEntry === idx;
+
+            var te = el('div', {className: 'timeline-entry' + (isSelected ? ' selected' : ''), 'data-idx': idx});
+            te.appendChild(el('div', {className: 'timeline-dot'}));
+
+            var card = el('div', {className: 'timeline-card'});
+            card.addEventListener('click', (function(i) { return function() { viewEntry(i); }; })(idx));
+
+            var meta = el('div', {className: 'timeline-meta'});
+            if (idx === 0) {
+                var s = el('span');
+                s.appendChild(el('strong', {}, 'Current'));
+                meta.appendChild(s);
+            } else {
+                meta.appendChild(el('span', {}, '#' + (idx + 1)));
+            }
+            var metaRight = el('span');
+            if (block) metaRight.appendChild(document.createTextNode('\u25A2 ' + block + '  '));
+            if (timestamp) metaRight.appendChild(document.createTextNode('\u23F0 ' + timestamp));
+            meta.appendChild(metaRight);
+            card.appendChild(meta);
+
+            var cidRow = el('div', {style: 'display:flex;align-items:center;gap:8px;'});
+            var cb = el('input', {type: 'checkbox', className: 'diff-select', 'data-idx': idx});
+            if (diffSelections.includes(idx)) cb.checked = true;
+            cb.addEventListener('change', (function(i) {
+                return function(e) { e.stopPropagation(); toggleDiffSelect(i, this); };
+            })(idx));
+            cb.addEventListener('click', function(e) { e.stopPropagation(); });
+            cidRow.appendChild(cb);
+
+            var cidSpan = el('span', {className: 'timeline-cid'}, truncateCid(cid));
+            var cpBtn = el('button', {className: 'copy-btn', title: 'Copy CID'});
+            cpBtn.addEventListener('click', (function(c) {
+                return function(e) { e.stopPropagation(); copyText(c); };
+            })(cid));
+            cpBtn.appendChild(el('i', {className: 'fas fa-copy'}));
+            cidSpan.appendChild(document.createTextNode(' '));
+            cidSpan.appendChild(cpBtn);
+            cidRow.appendChild(cidSpan);
+            card.appendChild(cidRow);
+
+            te.appendChild(card);
+            timeline.appendChild(te);
+        });
+
+        section.appendChild(timeline);
+
+        if (hasMore) {
+            var loadMoreRow = el('div', {className: 'load-more-row'});
+            var lmBtn = el('button', {className: 'btn btn-sm btn-outline', onClick: function() { loadMore(); }});
+            lmBtn.appendChild(el('i', {className: 'fas fa-chevron-down'}));
+            lmBtn.appendChild(document.createTextNode(' Load More'));
+            loadMoreRow.appendChild(lmBtn);
+            section.appendChild(loadMoreRow);
+        }
+    }
+
+    async function viewEntry(idx) {
+        selectedEntry = idx;
+        renderTimeline();
+
+        var entry = historyEntries[idx];
+        var cid = entry.cid || entry.cidV0 || '';
+        var detailSection = document.getElementById('detailSection');
+        detailSection.textContent = '';
+
+        var panel = el('div', {className: 'detail-panel'});
+        var header = el('div', {className: 'detail-header'});
+        header.appendChild(el('span', {}, 'Profile at CID: ' + truncateCid(cid)));
+        var copyHdr = el('button', {className: 'copy-btn', title: 'Copy full CID',
+            onClick: function() { copyText(cid); }});
+        copyHdr.appendChild(el('i', {className: 'fas fa-copy'}));
+        copyHdr.appendChild(document.createTextNode(' Copy CID'));
+        header.appendChild(copyHdr);
+        panel.appendChild(header);
+
+        var body = el('div', {className: 'detail-body'});
+        body.appendChild(el('span', {className: 'loader'}));
+        body.appendChild(document.createTextNode(' Loading...'));
+        panel.appendChild(body);
+        detailSection.appendChild(panel);
+
+        try {
+            var content = await fetchCidContent(cid);
+            body.textContent = '';
+            var pre = el('pre', {}, JSON.stringify(content, null, 2));
+            body.appendChild(pre);
+        } catch (err) {
+            body.textContent = '';
+            body.appendChild(el('div', {className: 'error-msg'}, 'Failed to load CID content: ' + err.message));
+        }
+    }
+
+    function toggleDiffSelect(idx, checkbox) {
+        if (checkbox.checked) {
+            if (diffSelections.length >= 2) {
+                diffSelections.shift();
+            }
+            diffSelections.push(idx);
+        } else {
+            diffSelections = diffSelections.filter(function(i) { return i !== idx; });
+        }
+
+        document.querySelectorAll('.diff-select').forEach(function(cb) {
+            cb.checked = diffSelections.includes(parseInt(cb.getAttribute('data-idx')));
+        });
+
+        var diffBtn = document.getElementById('diffBtn');
+        diffBtn.disabled = diffSelections.length !== 2;
+        diffBtn.textContent = '';
+        diffBtn.appendChild(el('i', {className: 'fas fa-code-compare'}));
+        diffBtn.appendChild(document.createTextNode(' Compare Selected (' + diffSelections.length + '/2)'));
+    }
+
+    async function showDiff() {
+        if (diffSelections.length !== 2) return;
+
+        var sorted = diffSelections.slice().sort(function(a, b) { return a - b; });
+        var idxA = sorted[0], idxB = sorted[1];
+        var entryA = historyEntries[idxA];
+        var entryB = historyEntries[idxB];
+        var cidA = entryA.cid || entryA.cidV0;
+        var cidB = entryB.cid || entryB.cidV0;
+
+        var detailSection = document.getElementById('detailSection');
+        detailSection.textContent = '';
+
+        var panel = el('div', {className: 'detail-panel'});
+        var header = el('div', {className: 'detail-header'});
+        header.appendChild(el('span', {}, 'Diff: #' + (idxA + 1) + ' vs #' + (idxB + 1)));
+        panel.appendChild(header);
+        var body = el('div', {className: 'detail-body'});
+        body.appendChild(el('span', {className: 'loader'}));
+        body.appendChild(document.createTextNode(' Loading both CIDs...'));
+        panel.appendChild(body);
+        detailSection.appendChild(panel);
+
+        try {
+            var [contentA, contentB] = await Promise.all([
+                fetchCidContent(cidA),
+                fetchCidContent(cidB)
+            ]);
+            renderDiff(contentA, contentB, cidA, cidB, idxA, idxB);
+        } catch (err) {
+            body.textContent = '';
+            body.appendChild(el('div', {className: 'error-msg'}, 'Diff failed: ' + err.message));
+        }
+    }
+
+    function renderDiff(objA, objB, cidA, cidB, idxA, idxB) {
+        // Recursive diff: walks nested objects/arrays and emits per-leaf lines
+        function diffLines(a, b, prefix) {
+            var lines = [];
+            if (a === b || JSON.stringify(a) === JSON.stringify(b)) {
+                // identical subtree — emit collapsed
+                lines.push({cls: 'diff-unchanged', textA: prefix + JSON.stringify(a), textB: prefix + JSON.stringify(b)});
+                return lines;
+            }
+            var aIsObj = a !== null && typeof a === 'object' && !Array.isArray(a);
+            var bIsObj = b !== null && typeof b === 'object' && !Array.isArray(b);
+            if (aIsObj && bIsObj) {
+                var keys = Array.from(new Set(Object.keys(a).concat(Object.keys(b)))).sort();
+                keys.forEach(function(k) {
+                    var childPrefix = prefix ? prefix + '.' + k : k;
+                    if (!(k in a)) {
+                        lines.push({cls: 'diff-added', textA: '', textB: childPrefix + ': ' + JSON.stringify(b[k])});
+                    } else if (!(k in b)) {
+                        lines.push({cls: 'diff-removed', textA: childPrefix + ': ' + JSON.stringify(a[k]), textB: ''});
+                    } else {
+                        lines = lines.concat(diffLines(a[k], b[k], childPrefix));
+                    }
+                });
+                return lines;
+            }
+            var aIsArr = Array.isArray(a);
+            var bIsArr = Array.isArray(b);
+            if (aIsArr && bIsArr) {
+                var maxLen = Math.max(a.length, b.length);
+                for (var i = 0; i < maxLen; i++) {
+                    var idxPrefix = prefix + '[' + i + ']';
+                    if (i >= a.length) {
+                        lines.push({cls: 'diff-added', textA: '', textB: idxPrefix + ': ' + JSON.stringify(b[i])});
+                    } else if (i >= b.length) {
+                        lines.push({cls: 'diff-removed', textA: idxPrefix + ': ' + JSON.stringify(a[i]), textB: ''});
+                    } else {
+                        lines = lines.concat(diffLines(a[i], b[i], idxPrefix));
+                    }
+                }
+                return lines;
+            }
+            // Leaf difference
+            lines.push({
+                cls: 'diff-changed',
+                textA: prefix + ': ' + JSON.stringify(a),
+                textB: prefix + ': ' + JSON.stringify(b)
+            });
+            return lines;
+        }
+
+        var lines = diffLines(objA || {}, objB || {}, '');
+
+        var detailSection = document.getElementById('detailSection');
+        detailSection.textContent = '';
+
+        var panel = el('div', {className: 'detail-panel'});
+        var header = el('div', {className: 'detail-header'});
+        header.appendChild(el('span', {}, 'Diff: #' + (idxA + 1) + ' vs #' + (idxB + 1)));
+        panel.appendChild(header);
+
+        var body = el('div', {className: 'detail-body'});
+        var container = el('div', {className: 'diff-container'});
+
+        var sideA = el('div', {className: 'diff-side'});
+        sideA.appendChild(el('h3', {}, '#' + (idxA + 1) + ' \u2014 ' + truncateCid(cidA)));
+        var sideB = el('div', {className: 'diff-side'});
+        sideB.appendChild(el('h3', {}, '#' + (idxB + 1) + ' \u2014 ' + truncateCid(cidB)));
+
+        lines.forEach(function(l) {
+            var lineA = el('div', {className: 'diff-line ' + (l.cls === 'diff-changed' ? 'diff-removed' : l.cls === 'diff-added' ? '' : l.cls)});
+            lineA.textContent = l.textA || '\u00A0';
+            sideA.appendChild(lineA);
+
+            var lineB = el('div', {className: 'diff-line ' + (l.cls === 'diff-changed' ? 'diff-added' : l.cls === 'diff-removed' ? '' : l.cls)});
+            lineB.textContent = l.textB || '\u00A0';
+            sideB.appendChild(lineB);
+        });
+
+        container.appendChild(sideA);
+        container.appendChild(sideB);
+        body.appendChild(container);
+        panel.appendChild(body);
+        detailSection.appendChild(panel);
+    }
+    </script>
+</body>
+</html>

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -982,6 +982,8 @@
                 fetchCidContent(cidA),
                 fetchCidContent(cidB)
             ]);
+            // Strip _source metadata before diffing
+            delete contentA._source; delete contentB._source;
             renderDiff(contentA, contentB, cidA, cidB, idxA, idxB);
         } catch (err) {
             var body = document.getElementById('inspectBody');

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -634,7 +634,7 @@
         cidLine.appendChild(copyBtn);
         info.appendChild(cidLine);
 
-        var linkRow = el('div', {style: 'margin-top:6px;'});
+        var linkRow = el('div', {style: 'margin-top:6px;display:flex;gap:6px;flex-wrap:wrap;'});
         var profileLink = el('a', {
             href: 'profileChecker.html?address=' + address,
             className: 'btn btn-sm btn-outline',
@@ -643,6 +643,15 @@
         profileLink.appendChild(el('i', {className: 'fas fa-user'}));
         profileLink.appendChild(document.createTextNode(' On-chain Profile'));
         linkRow.appendChild(profileLink);
+        var scanLink = el('a', {
+            href: 'https://gnosisscan.io/address/' + address,
+            target: '_blank',
+            className: 'btn btn-sm btn-outline',
+            style: 'text-decoration:none;display:inline-flex;align-items:center;gap:4px;'
+        });
+        scanLink.appendChild(el('i', {className: 'fas fa-arrow-up-right-from-square'}));
+        scanLink.appendChild(document.createTextNode(' Gnosisscan'));
+        linkRow.appendChild(scanLink);
         info.appendChild(linkRow);
 
         card.appendChild(info);

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -6,6 +6,19 @@
     <title>Profile CID History</title>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
+    <script>
+    var ethersLoaded = false;
+    function loadEthers() {
+        if (ethersLoaded) return Promise.resolve();
+        return new Promise(function(resolve, reject) {
+            var s = document.createElement('script');
+            s.src = 'https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js';
+            s.onload = function() { ethersLoaded = true; resolve(); };
+            s.onerror = reject;
+            document.head.appendChild(s);
+        });
+    }
+    </script>
     <style>
         :root {
             --primary: #191568;
@@ -343,6 +356,23 @@
             cursor: pointer;
         }
         .cid-inspect-link:hover { text-decoration-style: solid; color: var(--accent); }
+        .btn-restore {
+            background: var(--accent);
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            padding: 4px 12px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            cursor: pointer;
+            font-family: inherit;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            transition: background 0.2s;
+        }
+        .btn-restore:hover { background: #e0400f; }
+        .btn-restore:disabled { opacity: 0.5; cursor: not-allowed; }
 
         @media (max-width: 600px) {
             .diff-container { grid-template-columns: 1fr; }
@@ -877,6 +907,19 @@
         var cid = entry.cid || entry.cidV0 || '';
         var label = idx === 0 ? 'Current' : '#' + (idx + 1);
         openPanel(label + ' \u2014 ' + cid, cid);
+
+        // Show restore button for non-current entries
+        var actions = document.querySelector('.inspect-header .header-actions');
+        var oldRestore = document.getElementById('restoreBtn');
+        if (oldRestore) oldRestore.remove();
+        if (idx > 0 && cid) {
+            var restoreBtn = el('button', {className: 'btn-restore', id: 'restoreBtn',
+                onClick: (function(c) { return function() { restoreProfile(c); }; })(cid)});
+            restoreBtn.appendChild(el('i', {className: 'fas fa-rotate-left'}));
+            restoreBtn.appendChild(document.createTextNode(' Restore'));
+            actions.insertBefore(restoreBtn, actions.firstChild);
+        }
+
         panelLoading();
         try {
             var content = await fetchCidContent(cid);
@@ -998,6 +1041,77 @@
         container.appendChild(sideA);
         container.appendChild(sideB);
         body.appendChild(container);
+    }
+
+    // ─── Profile Restore (rollback CID on-chain) ─────────────────────
+    var NAME_REGISTRY = '0xA27566fD89162cC3D40Cb59c87AAaA49B85F3474';
+    var NAME_REGISTRY_ABI = ['function updateMetadataDigest(bytes32 _metadataDigest)'];
+
+    // Base58 decoder (CIDv0 uses base58btc)
+    var B58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+    function base58Decode(str) {
+        var bytes = [0];
+        for (var i = 0; i < str.length; i++) {
+            var c = B58_ALPHABET.indexOf(str[i]);
+            if (c < 0) throw new Error('Invalid base58 char: ' + str[i]);
+            for (var j = 0; j < bytes.length; j++) bytes[j] *= 58;
+            bytes[0] += c;
+            var carry = 0;
+            for (var j = 0; j < bytes.length; j++) {
+                bytes[j] += carry;
+                carry = (bytes[j] >> 8);
+                bytes[j] &= 0xff;
+            }
+            while (carry) { bytes.push(carry & 0xff); carry >>= 8; }
+        }
+        for (var i = 0; i < str.length && str[i] === '1'; i++) bytes.push(0);
+        return new Uint8Array(bytes.reverse());
+    }
+
+    function cidV0ToBytes32(cidV0) {
+        var raw = base58Decode(cidV0);
+        if (raw.length < 34 || raw[0] !== 0x12 || raw[1] !== 0x20)
+            throw new Error('Invalid CIDv0 format');
+        var digest = raw.slice(2, 34);
+        return '0x' + Array.from(digest).map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+    }
+
+    async function restoreProfile(cid) {
+        if (!cid || !currentAddress) return;
+        if (!confirm('Restore profile to CID:\n' + cid + '\n\nThis will update your on-chain profile metadata. You must be the owner of address ' + currentAddress + '.'))
+            return;
+
+        var restoreBtn = document.getElementById('restoreBtn');
+        if (restoreBtn) { restoreBtn.disabled = true; restoreBtn.textContent = 'Connecting...'; }
+
+        try {
+            await loadEthers();
+            if (!window.ethereum) throw new Error('No wallet found. Install MetaMask or similar.');
+
+            var provider = new ethers.providers.Web3Provider(window.ethereum);
+            await provider.send('eth_requestAccounts', []);
+            var signer = provider.getSigner();
+            var signerAddr = await signer.getAddress();
+
+            if (signerAddr.toLowerCase() !== currentAddress.toLowerCase())
+                throw new Error('Connected wallet (' + signerAddr.slice(0,6) + '...) does not match profile address (' + currentAddress.slice(0,6) + '...).');
+
+            if (restoreBtn) restoreBtn.textContent = 'Sending tx...';
+            var bytes32 = cidV0ToBytes32(cid);
+            var contract = new ethers.Contract(NAME_REGISTRY, NAME_REGISTRY_ABI, signer);
+            var tx = await contract.updateMetadataDigest(bytes32);
+
+            if (restoreBtn) restoreBtn.textContent = 'Confirming...';
+            await tx.wait();
+
+            if (restoreBtn) { restoreBtn.textContent = 'Restored!'; restoreBtn.style.background = 'var(--success)'; }
+            setTimeout(function() { checkHistory(); }, 2000);
+        } catch (err) {
+            console.error('Restore failed:', err);
+            if (restoreBtn) { restoreBtn.disabled = false; restoreBtn.textContent = 'Restore'; }
+            var body = document.getElementById('inspectBody');
+            if (body) body.appendChild(el('div', {className: 'error-msg', style: 'margin-top:8px;'}, 'Restore failed: ' + (err.reason || err.message)));
+        }
     }
     </script>
 </body>

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -193,10 +193,15 @@
             background: #f0eef9;
             padding: 2px 8px;
             border-radius: 3px;
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
+            display: inline-block;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            cursor: pointer;
+            text-decoration: none;
         }
+        .timeline-cid:hover { color: var(--accent); }
         .timeline-actions {
             display: flex;
             gap: 6px;
@@ -599,7 +604,7 @@
         var cidLine = el('div', {className: 'cid-line'});
         var cidLink = el('a', {href: '#', className: 'cid-inspect-link', title: 'Inspect CID content',
             onClick: function(e) { e.preventDefault(); inspectCid(cid, 'Current profile'); }});
-        cidLink.textContent = 'CID: ' + truncateCid(cid);
+        cidLink.textContent = 'CID: ' + cid;
         cidLine.appendChild(cidLink);
         var copyBtn = el('button', {className: 'copy-btn', title: 'Copy CID',
             onClick: function() { copyText(cid); }});
@@ -671,8 +676,14 @@
                 meta.appendChild(el('span', {}, '#' + (idx + 1)));
             }
             var metaRight = el('span');
-            if (block) metaRight.appendChild(document.createTextNode('\u25A2 ' + block + '  '));
-            if (timestamp) metaRight.appendChild(document.createTextNode('\u23F0 ' + timestamp));
+            if (block) {
+                metaRight.appendChild(el('i', {className: 'fas fa-cube', style: 'margin-right:3px;font-size:0.8em;'}));
+                metaRight.appendChild(document.createTextNode(block + '  '));
+            }
+            if (timestamp) {
+                metaRight.appendChild(el('i', {className: 'fas fa-clock', style: 'margin-right:3px;font-size:0.8em;'}));
+                metaRight.appendChild(document.createTextNode(timestamp));
+            }
             meta.appendChild(metaRight);
             card.appendChild(meta);
 
@@ -687,7 +698,7 @@
 
             var cidLink = el('a', {href: '#', className: 'timeline-cid', title: 'Inspect CID content',
                 style: 'cursor:pointer;text-decoration:none;'});
-            cidLink.textContent = truncateCid(cid);
+            cidLink.textContent = cid;
             cidLink.addEventListener('click', (function(i) {
                 return function(e) { e.preventDefault(); e.stopPropagation(); viewEntry(i); };
             })(idx));

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -300,7 +300,11 @@
     <div class="container">
         <div class="api-config">
             <i class="fas fa-server"></i>
-            API: <code id="apiUrlDisplay"></code>
+            <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
+                <option value="https://rpc.aboutcircles.com/profiles">Production</option>
+                <option value="https://staging.aboutcircles.com/profiles">Staging</option>
+            </select>
+            <code id="apiUrlDisplay"></code>
         </div>
 
         <div class="input-row">
@@ -331,14 +335,22 @@
 
     // Allow override via ?pinningApi= or ?api= query param
     (function initConfig() {
-        const params = new URLSearchParams(window.location.search);
-        const override = params.get('pinningApi') || params.get('api');
-        if (override) {
-            apiBase = override.replace(/\/+$/, '');
+        var params = new URLSearchParams(window.location.search);
+        var override = params.get('pinningApi') || params.get('api');
+        if (override) apiBase = override.replace(/\/+$/, '');
+
+        var sel = document.getElementById('endpointSelect');
+        for (var i = 0; i < sel.options.length; i++) {
+            if (sel.options[i].value === apiBase) { sel.selectedIndex = i; break; }
         }
         document.getElementById('apiUrlDisplay').textContent = apiBase;
 
-        const addr = params.get('address');
+        sel.addEventListener('change', function() {
+            apiBase = this.value;
+            document.getElementById('apiUrlDisplay').textContent = apiBase;
+        });
+
+        var addr = params.get('address');
         if (addr) {
             document.getElementById('addressInput').value = addr;
             setTimeout(function() { checkHistory(); }, 50);

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -408,6 +408,7 @@
     let diffSelections = [];   // max 2 CID indices for diffing
     let currentAddress = null;
     let offset = 0;
+    let viewGeneration = 0;    // race guard for rapid viewEntry clicks
     let hasMore = true;
 
     // Allow override via ?pinningApi= or ?api= query param
@@ -462,7 +463,7 @@
             if (k === 'className') e.className = v;
             else if (k === 'textContent') e.textContent = v;
             else if (k.startsWith('on')) e.addEventListener(k.slice(2).toLowerCase(), v);
-            else e.setAttribute(k, v);
+            else if (v !== undefined && v !== null) e.setAttribute(k, v);
         });
         if (children) {
             if (typeof children === 'string') e.textContent = children;
@@ -783,13 +784,13 @@
             notice.appendChild(el('i', {className: 'fas fa-triangle-exclamation', style: 'margin-right:6px;'}));
             notice.appendChild(document.createTextNode('Fetched via /raw fallback (CID was GC\'d, re-fetched from IPFS gateway)'));
             body.appendChild(notice);
-            delete obj._source;
         }
         if (typeof obj !== 'object' || obj === null) {
             body.appendChild(el('pre', {}, JSON.stringify(obj, null, 2)));
             return;
         }
         Object.keys(obj).forEach(function(key) {
+            if (key === '_source') return;
             var val = obj[key];
             var strVal = typeof val === 'string' ? val : JSON.stringify(val, null, 2);
 
@@ -855,18 +856,25 @@
     }
 
     async function viewEntry(idx) {
+        // Update selected state via class toggle instead of full rebuild
+        var prev = document.querySelector('.timeline-entry.selected');
+        if (prev) prev.classList.remove('selected');
+        var cur = document.querySelector('.timeline-entry[data-idx="' + idx + '"]');
+        if (cur) cur.classList.add('selected');
         selectedEntry = idx;
-        renderTimeline();
 
+        var gen = ++viewGeneration;
         var entry = historyEntries[idx];
         var cid = entry.cid || entry.cidV0 || '';
         var label = idx === 0 ? 'Current' : '#' + (idx + 1);
-        openPanel(label + ' — ' + cid, cid);
+        openPanel(label + ' \u2014 ' + cid, cid);
         panelLoading();
         try {
             var content = await fetchCidContent(cid);
+            if (gen !== viewGeneration) return; // stale — newer click superseded
             renderJsonWithPreviews(content);
         } catch (err) {
+            if (gen !== viewGeneration) return;
             var body = document.getElementById('inspectBody');
             body.textContent = '';
             body.appendChild(el('div', {className: 'error-msg'}, 'Failed: ' + err.message));
@@ -897,7 +905,8 @@
     async function showDiff() {
         if (diffSelections.length !== 2) return;
 
-        var sorted = diffSelections.slice().sort(function(a, b) { return a - b; });
+        // Sort so older entry (higher index) is on left, newer on right
+        var sorted = diffSelections.slice().sort(function(a, b) { return b - a; });
         var idxA = sorted[0], idxB = sorted[1];
         var entryA = historyEntries[idxA];
         var entryB = historyEntries[idxB];

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -404,8 +404,8 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
+                <option value="https://rpc.aboutcircles.com/profiles">Production</option>
                 <option value="https://profiles.staging.aboutcircles.com">Staging</option>
-                <option value="https://profiles.aboutcircles.com">Production</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>
@@ -438,7 +438,7 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    const DEFAULT_API = 'https://profiles.staging.aboutcircles.com';
+    const DEFAULT_API = 'https://rpc.aboutcircles.com/profiles';
     const PAGE_SIZE = 50;
 
     let apiBase = DEFAULT_API;

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -301,8 +301,7 @@
         <div class="api-config">
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
-                <option value="https://rpc.aboutcircles.com/profiles">Production</option>
-                <option value="https://staging.aboutcircles.com/profiles">Staging</option>
+                <option value="https://profiles.staging.aboutcircles.com">Staging</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>
@@ -321,8 +320,8 @@
 
     <script>
     // ─── Configuration ───────────────────────────────────────────────
-    const DEFAULT_API = 'https://rpc.aboutcircles.com/profiles';
-    const FALLBACK_API = 'https://staging.aboutcircles.com/profiles';
+    const DEFAULT_API = 'https://profiles.staging.aboutcircles.com';
+    // prod subdomain (profiles.aboutcircles.com) not yet live; will migrate later
     const PAGE_SIZE = 50;
 
     let apiBase = DEFAULT_API;
@@ -397,19 +396,19 @@
 
     // ─── API helpers ─────────────────────────────────────────────────
     async function fetchCurrentProfile(address) {
-        var res = await fetch(apiBase + '/api/profile/' + address);
+        var res = await fetch(apiBase + '/profile/' + address);
         if (!res.ok) throw new Error('Profile fetch failed: ' + res.status);
         return res.json();
     }
 
     async function fetchCidHistory(address, limit, off) {
-        var res = await fetch(apiBase + '/api/avatar/' + address + '/history?limit=' + limit + '&offset=' + off);
+        var res = await fetch(apiBase + '/avatar/' + address + '/history?limit=' + limit + '&offset=' + off);
         if (!res.ok) throw new Error('History fetch failed: ' + res.status);
         return res.json();
     }
 
     async function fetchCidContent(cid) {
-        var res = await fetch(apiBase + '/api/get?cid=' + encodeURIComponent(cid));
+        var res = await fetch(apiBase + '/get?cid=' + encodeURIComponent(cid));
         if (!res.ok) throw new Error('CID content fetch failed: ' + res.status);
         return res.json();
     }

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -542,7 +542,21 @@
             ]);
 
             if (profile.status === 'fulfilled' && profile.value) {
-                renderProfileCard(profile.value, addr);
+                var profileData = profile.value;
+                var profileCid = profileData.CID || profileData.cidV0 || profileData.cid;
+                renderProfileCard(profileData, addr);
+                // Async-fetch CID content to get avatar image (not in /profile response)
+                if (profileCid) {
+                    fetchCidContent(profileCid).then(function(cidData) {
+                        var imgUrl = cidData.previewImageUrl || cidData.imageUrl || '';
+                        if (imgUrl) {
+                            var avatarEl = document.getElementById('profileAvatar');
+                            var placeholderEl = document.getElementById('profileAvatarPlaceholder');
+                            if (avatarEl) { avatarEl.src = imgUrl; avatarEl.style.display = ''; }
+                            if (placeholderEl) placeholderEl.style.display = 'none';
+                        }
+                    }).catch(function() {});
+                }
             }
 
             if (history.status === 'fulfilled') {
@@ -594,18 +608,17 @@
 
         var card = el('div', {className: 'profile-card'});
 
-        // Avatar
-        if (avatarUrl) {
-            var img = el('img', {className: 'profile-avatar', alt: 'avatar'});
-            img.src = avatarUrl;
-            img.onerror = function() { this.style.display = 'none'; };
-            card.appendChild(img);
-        } else {
-            var placeholder = el('div', {className: 'profile-avatar',
-                style: 'display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:var(--text-muted);'});
-            placeholder.appendChild(el('i', {className: 'fas fa-user'}));
-            card.appendChild(placeholder);
-        }
+        // Avatar — img hidden until src is set (async from CID content)
+        var img = el('img', {className: 'profile-avatar', id: 'profileAvatar', alt: 'avatar'});
+        img.style.display = avatarUrl ? '' : 'none';
+        if (avatarUrl) img.src = avatarUrl;
+        img.onerror = function() { this.style.display = 'none'; };
+
+        var placeholder = el('div', {className: 'profile-avatar', id: 'profileAvatarPlaceholder',
+            style: 'display:' + (avatarUrl ? 'none' : 'flex') + ';align-items:center;justify-content:center;font-size:1.5rem;color:var(--text-muted);'});
+        placeholder.appendChild(el('i', {className: 'fas fa-user'}));
+        card.appendChild(img);
+        card.appendChild(placeholder);
 
         var info = el('div', {className: 'profile-info'});
         info.appendChild(el('h2', {}, name));

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -1128,15 +1128,17 @@
                 await connectWallet();
             }
 
-            // Step 2: Verify address match
-            if (connectedAddr.toLowerCase() !== currentAddress.toLowerCase()) {
-                alert('Wrong wallet connected!\n\nConnected: ' + connectedAddr + '\nNeeded: ' + currentAddress + '\n\nPlease switch to the correct account in your wallet and try again.');
-                if (restoreBtn) { restoreBtn.disabled = false; restoreBtn.textContent = 'Restore'; }
-                return;
+            // Step 2: Confirm (no strict address check — signer may be a Safe owner)
+            var isSameAddr = connectedAddr.toLowerCase() === currentAddress.toLowerCase();
+            var confirmMsg = 'Restore profile to CID:\n' + cid + '\n\n';
+            if (isSameAddr) {
+                confirmMsg += 'Sending tx from ' + connectedAddr.slice(0,6) + '...' + connectedAddr.slice(-4);
+            } else {
+                confirmMsg += 'Connected: ' + connectedAddr.slice(0,6) + '...' + connectedAddr.slice(-4) + '\n';
+                confirmMsg += 'Profile: ' + currentAddress.slice(0,6) + '...' + currentAddress.slice(-4) + '\n\n';
+                confirmMsg += 'If ' + currentAddress.slice(0,6) + '... is a Safe, ensure your connected account is an owner.';
             }
-
-            // Step 3: Confirm
-            if (!confirm('Restore profile to CID:\n' + cid + '\n\nThis sends a transaction from ' + connectedAddr.slice(0,6) + '...' + connectedAddr.slice(-4)))
+            if (!confirm(confirmMsg))
                 return;
 
             // Step 4: Send tx

--- a/profileHistory.html
+++ b/profileHistory.html
@@ -279,6 +279,13 @@
             transition: color 0.2s;
         }
         .copy-btn:hover { color: var(--primary); }
+        .cid-inspect-link {
+            color: var(--primary);
+            text-decoration: underline;
+            text-decoration-style: dotted;
+            cursor: pointer;
+        }
+        .cid-inspect-link:hover { text-decoration-style: solid; color: var(--accent); }
 
         @media (max-width: 600px) {
             .diff-container { grid-template-columns: 1fr; }
@@ -466,6 +473,7 @@
                 hasMore = entries.length >= PAGE_SIZE;
                 offset = entries.length;
                 renderTimeline();
+                if (entries.length > 0) viewEntry(0);
             } else {
                 timelineSection.textContent = '';
                 timelineSection.appendChild(el('div', {className: 'error-msg'},
@@ -504,7 +512,7 @@
 
         var name = profile.name || profile.username || 'Unknown';
         var avatarUrl = profile.previewImageUrl || profile.avatarUrl || '';
-        var cid = profile.cidV0 || profile.cid || 'N/A';
+        var cid = profile.CID || profile.cidV0 || profile.cid || 'N/A';
 
         var card = el('div', {className: 'profile-card'});
 
@@ -525,7 +533,10 @@
         info.appendChild(el('h2', {}, name));
 
         var cidLine = el('div', {className: 'cid-line'});
-        cidLine.appendChild(el('span', {}, 'CID: ' + truncateCid(cid)));
+        var cidLink = el('a', {href: '#', className: 'cid-inspect-link', title: 'Inspect CID content',
+            onClick: function(e) { e.preventDefault(); inspectCid(cid, 'Current profile'); }});
+        cidLink.textContent = 'CID: ' + truncateCid(cid);
+        cidLine.appendChild(cidLink);
         var copyBtn = el('button', {className: 'copy-btn', title: 'Copy CID',
             onClick: function() { copyText(cid); }});
         copyBtn.appendChild(el('i', {className: 'fas fa-copy'}));
@@ -610,15 +621,19 @@
             cb.addEventListener('click', function(e) { e.stopPropagation(); });
             cidRow.appendChild(cb);
 
-            var cidSpan = el('span', {className: 'timeline-cid'}, truncateCid(cid));
-            var cpBtn = el('button', {className: 'copy-btn', title: 'Copy CID'});
+            var cidLink = el('a', {href: '#', className: 'timeline-cid', title: 'Inspect CID content',
+                style: 'cursor:pointer;text-decoration:none;'});
+            cidLink.textContent = truncateCid(cid);
+            cidLink.addEventListener('click', (function(i) {
+                return function(e) { e.preventDefault(); e.stopPropagation(); viewEntry(i); };
+            })(idx));
+            cidRow.appendChild(cidLink);
+            var cpBtn = el('button', {className: 'copy-btn', title: 'Copy full CID'});
             cpBtn.addEventListener('click', (function(c) {
                 return function(e) { e.stopPropagation(); copyText(c); };
             })(cid));
             cpBtn.appendChild(el('i', {className: 'fas fa-copy'}));
-            cidSpan.appendChild(document.createTextNode(' '));
-            cidSpan.appendChild(cpBtn);
-            cidRow.appendChild(cidSpan);
+            cidRow.appendChild(cpBtn);
             card.appendChild(cidRow);
 
             te.appendChild(card);
@@ -634,6 +649,36 @@
             lmBtn.appendChild(document.createTextNode(' Load More'));
             loadMoreRow.appendChild(lmBtn);
             section.appendChild(loadMoreRow);
+        }
+    }
+
+    async function inspectCid(cid, label) {
+        var detailSection = document.getElementById('detailSection');
+        detailSection.textContent = '';
+
+        var panel = el('div', {className: 'detail-panel'});
+        var header = el('div', {className: 'detail-header'});
+        header.appendChild(el('span', {}, (label || 'CID') + ': ' + cid));
+        var copyHdr = el('button', {className: 'copy-btn', title: 'Copy full CID',
+            onClick: function() { copyText(cid); }});
+        copyHdr.appendChild(el('i', {className: 'fas fa-copy'}));
+        copyHdr.appendChild(document.createTextNode(' Copy'));
+        header.appendChild(copyHdr);
+        panel.appendChild(header);
+
+        var body = el('div', {className: 'detail-body'});
+        body.appendChild(el('span', {className: 'loader'}));
+        body.appendChild(document.createTextNode(' Loading...'));
+        panel.appendChild(body);
+        detailSection.appendChild(panel);
+
+        try {
+            var content = await fetchCidContent(cid);
+            body.textContent = '';
+            body.appendChild(el('pre', {}, JSON.stringify(content, null, 2)));
+        } catch (err) {
+            body.textContent = '';
+            body.appendChild(el('div', {className: 'error-msg'}, 'Failed to load: ' + err.message));
         }
     }
 

--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1212,11 +1212,10 @@
             <div class="server-select">
                 <label>Server:</label>
                 <select id="serverSelect" onchange="onServerChange()">
-                    <option value="staging2">Staging2 (New)</option>
                     <option value="staging">Staging</option>
                     <option value="prod">Production</option>
                 </select>
-                <span class="server-url" id="serverUrl">staging.circlesubi.network</span>
+                <span class="server-url" id="serverUrl">staging.aboutcircles.com</span>
             </div>
             <div class="server-status" id="serverStatus">
                 <span class="status-dot loading"></span>
@@ -1395,17 +1394,11 @@
     <script>
     // Server Configuration
     const SERVERS = {
-        staging2: {
-            name: 'Staging2 (New)',
-            rpc: 'https://staging.circlesubi.network/',
-            pathfinder: 'https://staging.circlesubi.network/',  // Also on root
-            chainRpc: 'https://rpc.gnosischain.com'
-        },
         staging: {
             name: 'Staging',
-            rpc: 'https://rpc.circlesubi.network/',
-            pathfinder: 'https://rpc.circlesubi.network/',
-            chainRpc: 'https://rpc.circlesubi.network/'
+            rpc: 'https://staging.aboutcircles.com/',
+            pathfinder: 'https://staging.aboutcircles.com/',
+            chainRpc: 'https://rpc.gnosischain.com'
         },
         prod: {
             name: 'Production',
@@ -1415,7 +1408,7 @@
         }
     };
 
-    let currentServer = 'staging2';
+    let currentServer = 'staging';
     let currentMethod = null;
     let lastResult = null;
     let lastRequest = null;
@@ -1549,8 +1542,8 @@
         },
         circles_findGroups: {
             category: 'trust',
-            description: 'Find groups with filters (staging2 only)',
-            serverNote: 'Only available on Staging2',
+            description: 'Find groups with filters (staging only)',
+            serverNote: 'Only available on Staging',
             params: [
                 { name: 'limit', type: 'number', required: false, default: 50, description: 'Max results' },
                 { name: 'queryParams', type: 'object', required: false, description: 'Filter params (nameStartsWith, symbolStartsWith, ownerIn)' },
@@ -2072,7 +2065,7 @@
             }
         });
 
-        // URL query parameter support: ?method=circlesV2_findPath&server=staging2
+        // URL query parameter support: ?method=circlesV2_findPath&server=staging
         var urlParams = new URLSearchParams(window.location.search);
         var paramServer = urlParams.get('server');
         if (paramServer && SERVERS[paramServer]) {

--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1212,10 +1212,10 @@
             <div class="server-select">
                 <label>Server:</label>
                 <select id="serverSelect" onchange="onServerChange()">
-                    <option value="staging">Staging</option>
                     <option value="prod">Production</option>
+                    <option value="staging">Staging</option>
                 </select>
-                <span class="server-url" id="serverUrl">staging.aboutcircles.com</span>
+                <span class="server-url" id="serverUrl">rpc.aboutcircles.com</span>
             </div>
             <div class="server-status" id="serverStatus">
                 <span class="status-dot loading"></span>
@@ -1408,7 +1408,7 @@
         }
     };
 
-    let currentServer = 'staging';
+    let currentServer = 'prod';
     let currentMethod = null;
     let lastResult = null;
     let lastRequest = null;

--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -2053,11 +2053,6 @@
         initSidebarResize();  // Setup sidebar collapse/resize
         loadHistory();
         loadLayoutPreference();  // This calls updateGridColumns()
-        // Set initial server URL display
-        var server = SERVERS[currentServer];
-        document.getElementById('serverUrl').textContent = server.rpc.replace('https://', '').replace(/\/$/, '');
-        checkServerStatus();
-
         document.addEventListener('keydown', function(e) {
             if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
                 e.preventDefault();
@@ -2071,10 +2066,11 @@
         if (paramServer && SERVERS[paramServer]) {
             currentServer = paramServer;
             document.getElementById('serverSelect').value = paramServer;
-            var server = SERVERS[paramServer];
-            document.getElementById('serverUrl').textContent = server.rpc.replace('https://', '').replace(/\/$/, '');
-            checkServerStatus();
         }
+        // Set server URL display and check status once (after param override)
+        var server = SERVERS[currentServer];
+        document.getElementById('serverUrl').textContent = server.rpc.replace('https://', '').replace(/\/$/, '');
+        checkServerStatus();
         var paramMethod = urlParams.get('method');
         if (paramMethod && METHODS[paramMethod]) {
             // Find the sidebar item and select it


### PR DESCRIPTION
## Summary

Two new standalone HTML diagnostic tools + cleanup of existing pages.

### New: `profileHistory.html` — Profile CID History Explorer
- Timeline of CID changes from the profile pinning service
- Fixed bottom inspect panel with drag-to-resize, closable
- Base64 image preview inline next to truncated data
- Recursive side-by-side diff (older left, newer right)
- `/raw/:cid` fallback for GC'd CIDs (re-fetches from IPFS gateway)
- **Profile restore**: rollback to any historical CID via NameRegistry `updateMetadataDigest` (wallet connection, Safe-aware)
- Endpoint selector (Production / Staging)

### New: `marketplaceExplorer.html` — Marketplace Explorer
- **Catalog tab**: product cards with images, prices, SKU, seller links, inventory badges
- **Sellers tab**: card layout with profile images, type badges (org/human/group), gateway count, action buttons (Products / Payments / Gnosisscan)
- **Payments tab**: on-chain payment gateway data from `CrcV2_PaymentGateway` indexer — summary stats, gateway registry, recent payments table with decoded references
- **Orders tab**: SIWE auth flow for buyer/seller order history (ethers.js lazy-loaded)
- Cross-tab navigation: seller name → seller card, seller card → filter catalog/payments, filter banners with jump links
- Gateway filtering (scoped to seller when filtered)
- Fuzzy text filter on all tabs
- URL state persistence (tab + filters survive refresh)

### Modified existing pages
- **`index.html`**: 2 new tool cards (Profile CID History, Marketplace Explorer)
- **`profileChecker.html`**: "CID History →" cross-link on address display
- **`rpcQueryView.html`**: consolidate staging URLs (`staging.circlesubi.network` / `rpc.circlesubi.network` → `staging.aboutcircles.com`), default to Production

### Infrastructure (separate)
- `aboutcircles-infrastructure`: changed `subdomain_services.market` default from `"market"` to `"market-api"`, deployed Caddy to both staging nodes

## Test plan
- [ ] profileHistory: test with address that has multiple CID changes (e.g. `0x42cEDde51198D1773590311E2A340DC06B24cB37`)
- [ ] profileHistory: test diff comparison between two CID versions
- [ ] profileHistory: test restore flow with correct wallet
- [ ] marketplaceExplorer: verify catalog loads on Production endpoint
- [ ] marketplaceExplorer: verify seller enrichment (names, type badges, profile images)
- [ ] marketplaceExplorer: verify payments tab shows on-chain data
- [ ] marketplaceExplorer: test cross-tab navigation (seller name → seller card, filter catalog by seller)
- [ ] rpcQueryView: verify staging/prod switching works, `?server=staging` URL param
- [ ] Cross-links: index.html cards, profileChecker CID History link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace Explorer: tabbed browsing of catalog, sellers, payments and authenticated orders (wallet sign‑in).
  * Profile CID History: timeline, inspect panel, side‑by‑side diffs and on‑chain restore.
  * Profile Checker: CID History link and Token Balances section with filters and sortable columns.
  * UI: two new tool cards added to the tools grid.

* **Configuration**
  * Updated RPC/server selection defaults and endpoint behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->