### PR TITLE
feat(rpcQueryView): clarify query vs paginated_query and add preset

### DIFF
--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1653,7 +1653,7 @@
         },
         circles_query: {
             category: 'query',
-            description: 'Generic database query using structured DTOs',
+            description: 'Generic database query (returns bare rows array, backwards compatible)',
             params: [
                 { name: 'namespace', type: 'string', required: true, description: 'Database namespace' },
                 { name: 'table', type: 'string', required: true, description: 'Table name' },
@@ -1847,7 +1847,7 @@
         },
         circles_paginated_query: {
             category: 'query',
-            description: 'Execute a structured query with cursor-based pagination (returns hasMore + nextCursor)',
+            description: 'Paginated query returning {rows, hasMore, nextCursor} wrapper',
             isQueryBuilder: true,
             params: [
                 { name: 'query', type: 'object', required: true, description: 'SelectDto query definition' },
@@ -1886,6 +1886,7 @@
         ],
         query: [
             { name: 'Query Avatars Table', method: 'circles_query', params: { namespace: 'V_Crc', table: 'Avatars', limit: 50 } },
+            { name: 'Paginated Avatars Query', method: 'circles_paginated_query', params: { namespace: 'V_Crc', table: 'Avatars', limit: 10 } },
             { name: 'Recent V2 Transfers', method: 'circles_events', params: { eventTypes: ['CrcV2_TransferSingle'] } },
             { name: 'TransferData Events', method: 'circles_events', params: { eventTypes: ['CrcV2_TransferData'] } },
             { name: 'List All Tables', method: 'circles_tables', params: {} }


### PR DESCRIPTION
## Summary
- Update `circles_query` description to clarify it returns bare `rows` array (backwards compatible)
- Update `circles_paginated_query` description to clarify it returns `{rows, hasMore, nextCursor}` wrapper
- Add "Paginated Avatars Query" preset (limit 10) for easy pagination testing

## Test plan
- [x] `circles_query` returns `{columns, rows}` on staging2, staging, prod
- [x] `circles_paginated_query` returns `{columns, rows, hasMore, nextCursor}` on all three servers
- [x] Preset loads correctly and populates form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Paginated Avatars Query" preset offering pre-configured default parameters to facilitate easier and faster access to paginated avatar query operations without manual setup.

* **Documentation**
  * Enhanced query method descriptions with clearer explanations of return value structures, backwards compatibility assurance, and cursor-based pagination mechanisms to improve user understanding and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->