### PR TITLE
feat(rpcQueryView): update circles_getTokenBalances description and add preset

### DIFF
--- a/profileHistory.html
+++ b/profileHistory.html
@@ -405,7 +405,7 @@
             <i class="fas fa-server"></i>
             <select id="endpointSelect" style="padding:4px 8px;border:1px solid var(--border);border-radius:4px;font-family:inherit;font-size:0.85rem;">
                 <option value="https://rpc.aboutcircles.com/profiles">Production</option>
-                <option value="https://profiles.staging.aboutcircles.com">Staging</option>
+                <option value="https://staging.circlesubi.network/profiles">Staging</option>
             </select>
             <code id="apiUrlDisplay"></code>
         </div>

--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1436,7 +1436,7 @@
         },
         circles_getTokenBalances: {
             category: 'balance',
-            description: 'Get all token balances with full metadata for an address',
+            description: 'Get all token balances with full metadata. Response includes isWrapped, isGroup, isInflationary, tokenType flags for client-side filtering (wrapped vs unwrapped, group, v1).',
             params: [
                 { name: 'address', type: 'address', required: true, description: 'Address to get balances for' }
             ]
@@ -1859,7 +1859,8 @@
         balance: [
             { name: 'Get V2 Total Balance', method: 'circlesV2_getTotalBalance', params: { address: '' } },
             { name: 'Get V1 Total Balance', method: 'circles_getTotalBalance', params: { address: '' } },
-            { name: 'Get All Token Balances', method: 'circles_getTokenBalances', params: { address: '' } }
+            { name: 'Get All Token Balances', method: 'circles_getTokenBalances', params: { address: '' } },
+            { name: 'Token Balances (example address)', method: 'circles_getTokenBalances', params: { address: '0x42cEDde51198D1773590311E2A340DC06B24cB37' } }
         ],
         avatar: [
             { name: 'Get Avatar Info', method: 'circles_getAvatarInfo', params: { address: '' } },


### PR DESCRIPTION
## Summary
- Fix profileHistory staging URL: `profiles.staging.aboutcircles.com` → `staging.circlesubi.network/profiles` (old subdomain has no DNS/TLS)
- Update `circles_getTokenBalances` description to mention client-side filter flags (`isWrapped`, `isGroup`, `isInflationary`, `tokenType`)
- Add preset with pre-filled example address

## Test plan
- [ ] profileHistory: switch to Staging → loads CID history
- [ ] rpcQueryView: circles_getTokenBalances presets dropdown shows "Token Balances (example address)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Updated the staging environment endpoint configuration to target the new backend infrastructure.

* **Documentation & Examples**
  * Enhanced documentation for token balance API methods, clearly documenting the response flags (`isWrapped`, `isGroup`, `isInflationary`, `tokenType`) provided in the results.
  * Added a supplementary preset example for token balance queries to demonstrate usage with different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->