### PR TITLE
feat(marketplace): rate timestamps + source tooltips for EUR pricing

### DIFF
--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -997,7 +997,7 @@
     }
 
     // ─── Pricing API (CRC → EUR conversion via metrics-exporter) ────
-    // Pricing API runs on staging nodes only (metrics-exporter, not on prod)
+    // Endpoint may not be available on all nodes (deploy_metrics_exporter flag)
     var PRICING_API = 'https://rpc.staging.aboutcircles.com/metrics-api/pricing';
     var priceCache = {};
     var priceInflight = {};  // dedup concurrent requests for same date
@@ -1178,36 +1178,47 @@
         stats.appendChild(eurCard);
         container.appendChild(stats);
 
-        // Compute EUR volume async (batch unique dates to minimize API calls)
-        (async function() {
-            var dateBuckets = {};  // { "2026-04-20": { crc: 123.4, ts: 1713571200 } }
-            allPayments.forEach(function(r) {
-                var dateStr = new Date(r[5] * 1000).toISOString().split('T')[0];
-                if (!dateBuckets[dateStr]) dateBuckets[dateStr] = { crc: 0, ts: r[5] };
-                dateBuckets[dateStr].crc += parseFloat(formatCrc(r[3]));
-            });
-            var totalEur = 0;
-            var hasEur = false;
-            var hasXdaiFallback = false;
-            for (var dateStr in dateBuckets) {
-                var bucket = dateBuckets[dateStr];
-                var price = await getCrcPrice(bucket.ts);
-                if (price && price.dcrc_eur > 0) {
-                    totalEur += bucket.crc * price.dcrc_eur;
-                    hasEur = true;
-                } else if (price && price.dcrc_xdai > 0) {
-                    totalEur += bucket.crc * price.dcrc_xdai;
-                    hasEur = true;
-                    hasXdaiFallback = true;
+        // Compute EUR volume async (batch unique dates to minimize API calls).
+        // Stored as volumeDone so per-row lookups can chain on it (avoids rate-limit race).
+        var volumeDone = (async function() {
+            try {
+                var dateBuckets = {};  // { "2026-04-20": { crc: 123.4, ts: 1713571200 } }
+                allPayments.forEach(function(r) {
+                    var ts = Number(r[5]);
+                    if (!isFinite(ts) || ts <= 0) return;  // skip bad timestamps
+                    var dateStr = new Date(ts * 1000).toISOString().split('T')[0];
+                    if (!dateBuckets[dateStr]) dateBuckets[dateStr] = { crc: 0, ts: ts };
+                    dateBuckets[dateStr].crc += parseFloat(formatCrc(r[3]));
+                });
+                var totalEur = 0;
+                var hasEur = false;
+                var hasXdaiFallback = false;
+                for (var dateStr in dateBuckets) {
+                    var bucket = dateBuckets[dateStr];
+                    var price = await getCrcPrice(bucket.ts);
+                    if (price && price.dcrc_eur > 0) {
+                        totalEur += bucket.crc * price.dcrc_eur;
+                        hasEur = true;
+                    } else if (price && price.dcrc_xdai > 0) {
+                        totalEur += bucket.crc * price.dcrc_xdai;
+                        hasEur = true;
+                        hasXdaiFallback = true;
+                    }
                 }
-            }
-            if (!eurValue.isConnected) return;
-            if (hasEur) {
-                eurValue.textContent = (hasXdaiFallback ? '~' : '') + '\u20AC' + totalEur.toFixed(2);
-                eurSource.textContent = 'Balancer + CoinGecko, daily rate' + (hasXdaiFallback ? ' (partial xDAI fallback)' : '');
-            } else {
-                eurValue.textContent = '\u2014';
-                eurSource.textContent = 'Rate data unavailable';
+                if (!eurValue.isConnected) return;
+                if (hasEur) {
+                    eurValue.textContent = (hasXdaiFallback ? '~' : '') + '\u20AC' + totalEur.toFixed(2);
+                    eurSource.textContent = 'Balancer V3 + CoinGecko, daily rate' + (hasXdaiFallback ? ' (partial xDAI fallback)' : '');
+                } else {
+                    eurValue.textContent = '\u2014';
+                    eurSource.textContent = 'Rate data unavailable';
+                }
+            } catch (err) {
+                console.warn('EUR volume computation failed', err);
+                if (eurValue.isConnected) {
+                    eurValue.textContent = '\u2014';
+                    eurSource.textContent = 'Computation error';
+                }
             }
         })();
 
@@ -1304,7 +1315,7 @@
             if (h === 'EUR Value') {
                 var info = el('span', {
                     style: 'cursor:help;margin-left:4px;font-weight:400;opacity:0.6;',
-                    title: 'Daily CRC/EUR rate from Balancer V3 pool price + CoinGecko DAI/EUR.\nGranularity: one rate per calendar day (UTC).\nIf EUR unavailable, xDAI equivalent shown instead.'
+                    title: 'CRC/EUR rate: Balancer V3 pool price (live for today, historic for past dates) + CoinGecko DAI/EUR.\nGranularity: one rate per calendar day (UTC).\nHover each row for exact rate, date, and source.\nIf EUR unavailable, xDAI equivalent shown instead.'
                 }, '\u24D8');
                 th.appendChild(info);
             }
@@ -1352,17 +1363,19 @@
             // Amount
             row.appendChild(el('td', {style: 'font-weight:600;color:var(--accent);white-space:nowrap;'}, formatCrc(r[3]) + ' CRC'));
 
-            // EUR Value (async, filled when price data arrives)
-            var eurCell = el('td', {style: 'white-space:nowrap;font-size:0.85rem;color:var(--text-muted);'}, '…');
+            // EUR Value — waits for volumeDone so all dates are cached (avoids rate-limit race)
+            var eurCell = el('td', {style: 'white-space:nowrap;font-size:0.85rem;color:var(--text-muted);'}, '\u2026');
             row.appendChild(eurCell);
             (function(cell, amount, timestamp) {
-                getCrcPrice(timestamp).then(function(price) {
+                var txDate = new Date(timestamp * 1000).toISOString().split('T')[0];
+                volumeDone.then(function() {
+                    return getCrcPrice(timestamp);
+                }).then(function(price) {
                     var crc = parseFloat(formatCrc(amount));
-                    var rateDate = price ? (price.date || new Date(timestamp * 1000).toISOString().split('T')[0]) : '';
+                    var rateDate = (price && price.date) ? price.date : txDate;
                     var source = price ? (price.source || 'unknown') : '';
                     var sourceLabel = source === 'balancer_live' ? 'Balancer V3 live'
-                        : source === 'balancer_historic' ? 'Balancer V3 historic'
-                        : source === 'cached' ? 'cached' : source;
+                        : source === 'balancer_historic' ? 'Balancer V3 historic' : source;
                     if (price && price.dcrc_eur > 0) {
                         var eur = (crc * price.dcrc_eur).toFixed(2);
                         cell.textContent = '\u20AC' + eur;
@@ -1374,14 +1387,18 @@
                         var xdai = (crc * price.dcrc_xdai).toFixed(4);
                         cell.textContent = '~$' + xdai + ' xDAI';
                         cell.style.fontSize = '0.8rem';
-                        cell.title = 'EUR rate unavailable \u2014 showing xDAI equivalent\n'
+                        cell.title = 'CoinGecko DAI/EUR unavailable \u2014 showing xDAI equivalent\n'
                             + '1 CRC = $' + price.dcrc_xdai.toFixed(6) + ' xDAI\n'
                             + 'Rate date: ' + rateDate + '\n'
                             + 'Source: ' + sourceLabel;
                     } else {
                         cell.textContent = '\u2014';
-                        cell.title = 'Price data unavailable for ' + rateDate;
+                        cell.title = 'Price data unavailable for ' + txDate;
                     }
+                }).catch(function(err) {
+                    console.warn('EUR conversion failed for ' + txDate, err);
+                    cell.textContent = '\u2014';
+                    cell.title = 'Price conversion error';
                 });
             })(eurCell, r[3], r[5]);
 

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -271,13 +271,10 @@
         .copy-btn:hover { color: var(--primary); }
 
         /* Click-to-show tooltip (replaces native title for touch support) */
-        .tip-wrap { position: relative; cursor: help; }
+        .tip-wrap { cursor: help; }
         .tip-bubble {
             display: none;
-            position: absolute;
-            bottom: calc(100% + 6px);
-            left: 50%;
-            transform: translateX(-50%);
+            position: fixed;
             background: var(--text);
             color: #fff;
             font-size: 0.75rem;
@@ -287,28 +284,8 @@
             white-space: pre-line;
             min-width: 220px;
             max-width: 320px;
-            z-index: 100;
+            z-index: 1000;
             box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-        }
-        .tip-bubble::after {
-            content: '';
-            position: absolute;
-            top: 100%;
-            left: 50%;
-            transform: translateX(-50%);
-            border: 5px solid transparent;
-            border-top-color: var(--text);
-        }
-        /* In table cells: show below to avoid clipping at top */
-        td.tip-wrap .tip-bubble {
-            bottom: auto;
-            top: calc(100% + 6px);
-        }
-        td.tip-wrap .tip-bubble::after {
-            top: auto;
-            bottom: 100%;
-            border-top-color: transparent;
-            border-bottom-color: var(--text);
         }
         .tip-wrap.tip-open .tip-bubble { display: block; }
 
@@ -486,7 +463,19 @@
         return e;
     }
 
-    // Click-to-show tooltip: wraps content in a .tip-wrap with a .tip-bubble
+    // Click-to-show tooltip: wraps content in a .tip-wrap with a fixed .tip-bubble
+    function positionBubble(wrap, bubble) {
+        var rect = wrap.getBoundingClientRect();
+        var bw = 280;  // approximate bubble width
+        // prefer below, fall back above if near bottom
+        var top = rect.bottom + 6;
+        if (top + 120 > window.innerHeight) top = rect.top - 6;  // rough check
+        var left = rect.left + rect.width / 2 - bw / 2;
+        if (left < 8) left = 8;
+        if (left + bw > window.innerWidth - 8) left = window.innerWidth - bw - 8;
+        bubble.style.top = top + 'px';
+        bubble.style.left = left + 'px';
+    }
     function tipWrap(content, tipText) {
         var wrap = el('span', {className: 'tip-wrap'});
         if (typeof content === 'string') wrap.textContent = content;
@@ -495,16 +484,19 @@
         wrap.appendChild(bubble);
         wrap.addEventListener('click', function(e) {
             e.stopPropagation();
-            // close any other open tooltip first
             document.querySelectorAll('.tip-open').forEach(function(o) { if (o !== wrap) o.classList.remove('tip-open'); });
+            positionBubble(wrap, bubble);
             wrap.classList.toggle('tip-open');
         });
         return wrap;
     }
-    // Close tooltips when clicking outside
+    // Close tooltips when clicking outside or scrolling
     document.addEventListener('click', function() {
         document.querySelectorAll('.tip-open').forEach(function(o) { o.classList.remove('tip-open'); });
     });
+    window.addEventListener('scroll', function() {
+        document.querySelectorAll('.tip-open').forEach(function(o) { o.classList.remove('tip-open'); });
+    }, true);
 
     function truncAddr(a) {
         if (!a) return '';
@@ -1437,6 +1429,7 @@
                 if (!eurBubble.textContent) return;
                 e.stopPropagation();
                 document.querySelectorAll('.tip-open').forEach(function(o) { if (o !== eurCell) o.classList.remove('tip-open'); });
+                positionBubble(eurCell, eurBubble);
                 eurCell.classList.toggle('tip-open');
             });
             row.appendChild(eurCell);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -712,9 +712,23 @@
                     });
                 })(sellerLine, sellerLink, sellerAddr);
             }
-            // Inventory badge — disabled: /inventory endpoint returns 404 for all products.
-            // TODO: re-enable when market-api inventory tracking is implemented.
-            // if (sku && sellerAddr) { ... }
+            // Inventory badge — construct URL from seller + SKU
+            if (sku && sellerAddr) {
+                var invBadge = el('div', {style: 'font-size:0.8rem;'});
+                metaBottom.appendChild(invBadge);
+                (function(b, s, k) {
+                    var invUrl = apiBase + '/inventory/inventory/100/' + s + '/' + encodeURIComponent(k);
+                    fetch(invUrl).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
+                        if (!data) return;
+                        var qty = data.value != null ? data.value : (data.quantity != null ? data.quantity : null);
+                        if (typeof qty === 'number') {
+                            var color = qty > 0 ? 'background:#dcfce7;color:#166534;' : 'background:#fee2e2;color:#991b1b;';
+                            b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;' + color},
+                                qty > 0 ? qty + ' in stock' : 'Out of stock'));
+                        }
+                    }).catch(function() {});
+                })(invBadge, sellerAddr, sku);
+            }
             card.appendChild(metaBottom);
 
             grid.appendChild(card);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -1171,8 +1171,10 @@
         // EUR Volume card (async, filled when price data arrives)
         var eurCard = el('div', {style: 'background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:12px 16px;min-width:120px;'});
         eurCard.appendChild(el('div', {style: 'font-size:0.8rem;color:var(--text-muted);'}, 'EUR Volume'));
-        var eurValue = el('div', {style: 'font-size:1.3rem;font-weight:700;'}, '…');
+        var eurValue = el('div', {style: 'font-size:1.3rem;font-weight:700;'}, '\u2026');
         eurCard.appendChild(eurValue);
+        var eurSource = el('div', {style: 'font-size:0.65rem;color:var(--text-muted);margin-top:2px;'});
+        eurCard.appendChild(eurSource);
         stats.appendChild(eurCard);
         container.appendChild(stats);
 
@@ -1186,6 +1188,7 @@
             });
             var totalEur = 0;
             var hasEur = false;
+            var hasXdaiFallback = false;
             for (var dateStr in dateBuckets) {
                 var bucket = dateBuckets[dateStr];
                 var price = await getCrcPrice(bucket.ts);
@@ -1195,9 +1198,17 @@
                 } else if (price && price.dcrc_xdai > 0) {
                     totalEur += bucket.crc * price.dcrc_xdai;
                     hasEur = true;
+                    hasXdaiFallback = true;
                 }
             }
-            if (eurValue.isConnected) eurValue.textContent = hasEur ? '€' + totalEur.toFixed(2) : '—';
+            if (!eurValue.isConnected) return;
+            if (hasEur) {
+                eurValue.textContent = (hasXdaiFallback ? '~' : '') + '\u20AC' + totalEur.toFixed(2);
+                eurSource.textContent = 'Balancer + CoinGecko, daily rate' + (hasXdaiFallback ? ' (partial xDAI fallback)' : '');
+            } else {
+                eurValue.textContent = '\u2014';
+                eurSource.textContent = 'Rate data unavailable';
+            }
         })();
 
         // Filter banner
@@ -1288,7 +1299,17 @@
         var table = el('table');
         var thead = el('thead');
         var hr = el('tr');
-        ['Time', 'Payer', 'Payee', 'Amount', 'EUR Value', 'Reference', 'Tx'].forEach(function(h) { hr.appendChild(el('th', {}, h)); });
+        ['Time', 'Payer', 'Payee', 'Amount', 'EUR Value', 'Reference', 'Tx'].forEach(function(h) {
+            var th = el('th', {}, h);
+            if (h === 'EUR Value') {
+                var info = el('span', {
+                    style: 'cursor:help;margin-left:4px;font-weight:400;opacity:0.6;',
+                    title: 'Daily CRC/EUR rate from Balancer V3 pool price + CoinGecko DAI/EUR.\nGranularity: one rate per calendar day (UTC).\nIf EUR unavailable, xDAI equivalent shown instead.'
+                }, '\u24D8');
+                th.appendChild(info);
+            }
+            hr.appendChild(th);
+        });
         thead.appendChild(hr);
         table.appendChild(thead);
 
@@ -1332,20 +1353,34 @@
             row.appendChild(el('td', {style: 'font-weight:600;color:var(--accent);white-space:nowrap;'}, formatCrc(r[3]) + ' CRC'));
 
             // EUR Value (async, filled when price data arrives)
-            var eurCell = el('td', {style: 'white-space:nowrap;font-size:0.85rem;color:var(--text-muted);'}, '—');
+            var eurCell = el('td', {style: 'white-space:nowrap;font-size:0.85rem;color:var(--text-muted);'}, '…');
             row.appendChild(eurCell);
             (function(cell, amount, timestamp) {
                 getCrcPrice(timestamp).then(function(price) {
+                    var crc = parseFloat(formatCrc(amount));
+                    var rateDate = price ? (price.date || new Date(timestamp * 1000).toISOString().split('T')[0]) : '';
+                    var source = price ? (price.source || 'unknown') : '';
+                    var sourceLabel = source === 'balancer_live' ? 'Balancer V3 live'
+                        : source === 'balancer_historic' ? 'Balancer V3 historic'
+                        : source === 'cached' ? 'cached' : source;
                     if (price && price.dcrc_eur > 0) {
-                        var crc = parseFloat(formatCrc(amount));
                         var eur = (crc * price.dcrc_eur).toFixed(2);
-                        cell.textContent = '€' + eur;
+                        cell.textContent = '\u20AC' + eur;
                         cell.style.color = 'var(--text)';
+                        cell.title = '1 CRC = \u20AC' + price.dcrc_eur.toFixed(6) + '\n'
+                            + 'Rate date: ' + rateDate + '\n'
+                            + 'Source: ' + sourceLabel + ' + CoinGecko DAI/EUR';
                     } else if (price && price.dcrc_xdai > 0) {
-                        var crc = parseFloat(formatCrc(amount));
                         var xdai = (crc * price.dcrc_xdai).toFixed(4);
-                        cell.textContent = '$' + xdai;
-                        cell.title = 'xDAI (EUR rate unavailable)';
+                        cell.textContent = '~$' + xdai + ' xDAI';
+                        cell.style.fontSize = '0.8rem';
+                        cell.title = 'EUR rate unavailable \u2014 showing xDAI equivalent\n'
+                            + '1 CRC = $' + price.dcrc_xdai.toFixed(6) + ' xDAI\n'
+                            + 'Rate date: ' + rateDate + '\n'
+                            + 'Source: ' + sourceLabel;
+                    } else {
+                        cell.textContent = '\u2014';
+                        cell.title = 'Price data unavailable for ' + rateDate;
                     }
                 });
             })(eurCell, r[3], r[5]);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -466,15 +466,24 @@
     // Click-to-show tooltip: wraps content in a .tip-wrap with a fixed .tip-bubble
     function positionBubble(wrap, bubble) {
         var rect = wrap.getBoundingClientRect();
-        var bw = 280;  // approximate bubble width
-        // prefer below, fall back above if near bottom
+        var bh = bubble.offsetHeight || 0;
+        var bw = bubble.offsetWidth || 280;
+        // prefer below, fall back above if near viewport bottom
         var top = rect.bottom + 6;
-        if (top + 120 > window.innerHeight) top = rect.top - 6;  // rough check
+        if (top + bh > window.innerHeight) top = rect.top - bh - 6;
         var left = rect.left + rect.width / 2 - bw / 2;
         if (left < 8) left = 8;
         if (left + bw > window.innerWidth - 8) left = window.innerWidth - bw - 8;
         bubble.style.top = top + 'px';
         bubble.style.left = left + 'px';
+    }
+    function toggleTip(wrap, bubble) {
+        var wasOpen = wrap.classList.contains('tip-open');
+        document.querySelectorAll('.tip-open').forEach(function(o) { o.classList.remove('tip-open'); });
+        if (wasOpen) return;  // was open → just closed, done
+        // open: show first so offsetHeight is measurable, then position
+        wrap.classList.add('tip-open');
+        positionBubble(wrap, bubble);
     }
     function tipWrap(content, tipText) {
         var wrap = el('span', {className: 'tip-wrap'});
@@ -484,9 +493,7 @@
         wrap.appendChild(bubble);
         wrap.addEventListener('click', function(e) {
             e.stopPropagation();
-            document.querySelectorAll('.tip-open').forEach(function(o) { if (o !== wrap) o.classList.remove('tip-open'); });
-            positionBubble(wrap, bubble);
-            wrap.classList.toggle('tip-open');
+            toggleTip(wrap, bubble);
         });
         return wrap;
     }
@@ -1428,9 +1435,7 @@
             eurCell.addEventListener('click', function(e) {
                 if (!eurBubble.textContent) return;
                 e.stopPropagation();
-                document.querySelectorAll('.tip-open').forEach(function(o) { if (o !== eurCell) o.classList.remove('tip-open'); });
-                positionBubble(eurCell, eurBubble);
-                eurCell.classList.toggle('tip-open');
+                toggleTip(eurCell, eurBubble);
             });
             row.appendChild(eurCell);
             (function(label, bubble, cell, amount, timestamp) {

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -712,23 +712,9 @@
                     });
                 })(sellerLine, sellerLink, sellerAddr);
             }
-            // Inventory badge — construct URL from seller + SKU
-            if (sku && sellerAddr) {
-                var invBadge = el('div', {style: 'font-size:0.8rem;'});
-                metaBottom.appendChild(invBadge);
-                (function(b, s, k) {
-                    var invUrl = apiBase + '/inventory/100/' + s + '/' + encodeURIComponent(k);
-                    fetch(invUrl).then(function(r) { return r.ok ? r.json() : null; }).then(function(data) {
-                        if (!data) return;
-                        var qty = data.value != null ? data.value : (data.quantity != null ? data.quantity : null);
-                        if (typeof qty === 'number') {
-                            var color = qty > 0 ? 'background:#dcfce7;color:#166534;' : 'background:#fee2e2;color:#991b1b;';
-                            b.appendChild(el('span', {style: 'font-size:0.7rem;padding:1px 6px;border-radius:8px;' + color},
-                                qty > 0 ? qty + ' in stock' : 'Out of stock'));
-                        }
-                    }).catch(function() {});
-                })(invBadge, sellerAddr, sku);
-            }
+            // Inventory badge — disabled: /inventory endpoint returns 404 for all products.
+            // TODO: re-enable when market-api inventory tracking is implemented.
+            // if (sku && sellerAddr) { ... }
             card.appendChild(metaBottom);
 
             grid.appendChild(card);

--- a/marketplaceExplorer.html
+++ b/marketplaceExplorer.html
@@ -269,6 +269,49 @@
             color: var(--text-muted); font-size: 0.85rem; padding: 2px;
         }
         .copy-btn:hover { color: var(--primary); }
+
+        /* Click-to-show tooltip (replaces native title for touch support) */
+        .tip-wrap { position: relative; cursor: help; }
+        .tip-bubble {
+            display: none;
+            position: absolute;
+            bottom: calc(100% + 6px);
+            left: 50%;
+            transform: translateX(-50%);
+            background: var(--text);
+            color: #fff;
+            font-size: 0.75rem;
+            line-height: 1.4;
+            padding: 8px 10px;
+            border-radius: 6px;
+            white-space: pre-line;
+            min-width: 220px;
+            max-width: 320px;
+            z-index: 100;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        }
+        .tip-bubble::after {
+            content: '';
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            border: 5px solid transparent;
+            border-top-color: var(--text);
+        }
+        /* In table cells: show below to avoid clipping at top */
+        td.tip-wrap .tip-bubble {
+            bottom: auto;
+            top: calc(100% + 6px);
+        }
+        td.tip-wrap .tip-bubble::after {
+            top: auto;
+            bottom: 100%;
+            border-top-color: transparent;
+            border-bottom-color: var(--text);
+        }
+        .tip-wrap.tip-open .tip-bubble { display: block; }
+
         .tab-filter {
             display: flex;
             align-items: center;
@@ -442,6 +485,26 @@
         }
         return e;
     }
+
+    // Click-to-show tooltip: wraps content in a .tip-wrap with a .tip-bubble
+    function tipWrap(content, tipText) {
+        var wrap = el('span', {className: 'tip-wrap'});
+        if (typeof content === 'string') wrap.textContent = content;
+        else wrap.appendChild(content);
+        var bubble = el('div', {className: 'tip-bubble'}, tipText);
+        wrap.appendChild(bubble);
+        wrap.addEventListener('click', function(e) {
+            e.stopPropagation();
+            // close any other open tooltip first
+            document.querySelectorAll('.tip-open').forEach(function(o) { if (o !== wrap) o.classList.remove('tip-open'); });
+            wrap.classList.toggle('tip-open');
+        });
+        return wrap;
+    }
+    // Close tooltips when clicking outside
+    document.addEventListener('click', function() {
+        document.querySelectorAll('.tip-open').forEach(function(o) { o.classList.remove('tip-open'); });
+    });
 
     function truncAddr(a) {
         if (!a) return '';
@@ -1313,11 +1376,12 @@
         ['Time', 'Payer', 'Payee', 'Amount', 'EUR Value', 'Reference', 'Tx'].forEach(function(h) {
             var th = el('th', {}, h);
             if (h === 'EUR Value') {
-                var info = el('span', {
-                    style: 'cursor:help;margin-left:4px;font-weight:400;opacity:0.6;',
-                    title: 'CRC/EUR rate: Balancer V3 pool price (live for today, historic for past dates) + CoinGecko DAI/EUR.\nGranularity: one rate per calendar day (UTC).\nHover each row for exact rate, date, and source.\nIf EUR unavailable, xDAI equivalent shown instead.'
-                }, '\u24D8');
-                th.appendChild(info);
+                var infoIcon = el('span', {style: 'margin-left:4px;font-weight:400;opacity:0.6;'}, '\u24D8');
+                th.appendChild(tipWrap(infoIcon,
+                    'CRC/EUR rate: Balancer V3 pool price (live for today, historic for past dates) + CoinGecko DAI/EUR.\n'
+                    + 'Granularity: one rate per calendar day (UTC).\n'
+                    + 'Click each row\u2019s EUR value for exact rate, date, and source.\n'
+                    + 'If EUR unavailable, xDAI equivalent shown instead.'));
             }
             hr.appendChild(th);
         });
@@ -1364,9 +1428,19 @@
             row.appendChild(el('td', {style: 'font-weight:600;color:var(--accent);white-space:nowrap;'}, formatCrc(r[3]) + ' CRC'));
 
             // EUR Value — waits for volumeDone so all dates are cached (avoids rate-limit race)
-            var eurCell = el('td', {style: 'white-space:nowrap;font-size:0.85rem;color:var(--text-muted);'}, '\u2026');
+            var eurCell = el('td', {className: 'tip-wrap', style: 'white-space:nowrap;font-size:0.85rem;color:var(--text-muted);'});
+            var eurLabel = el('span', {}, '\u2026');
+            var eurBubble = el('div', {className: 'tip-bubble'});
+            eurCell.appendChild(eurLabel);
+            eurCell.appendChild(eurBubble);
+            eurCell.addEventListener('click', function(e) {
+                if (!eurBubble.textContent) return;
+                e.stopPropagation();
+                document.querySelectorAll('.tip-open').forEach(function(o) { if (o !== eurCell) o.classList.remove('tip-open'); });
+                eurCell.classList.toggle('tip-open');
+            });
             row.appendChild(eurCell);
-            (function(cell, amount, timestamp) {
+            (function(label, bubble, cell, amount, timestamp) {
                 var txDate = new Date(timestamp * 1000).toISOString().split('T')[0];
                 volumeDone.then(function() {
                     return getCrcPrice(timestamp);
@@ -1378,29 +1452,29 @@
                         : source === 'balancer_historic' ? 'Balancer V3 historic' : source;
                     if (price && price.dcrc_eur > 0) {
                         var eur = (crc * price.dcrc_eur).toFixed(2);
-                        cell.textContent = '\u20AC' + eur;
+                        label.textContent = '\u20AC' + eur;
                         cell.style.color = 'var(--text)';
-                        cell.title = '1 CRC = \u20AC' + price.dcrc_eur.toFixed(6) + '\n'
+                        bubble.textContent = '1 CRC = \u20AC' + price.dcrc_eur.toFixed(6) + '\n'
                             + 'Rate date: ' + rateDate + '\n'
                             + 'Source: ' + sourceLabel + ' + CoinGecko DAI/EUR';
                     } else if (price && price.dcrc_xdai > 0) {
                         var xdai = (crc * price.dcrc_xdai).toFixed(4);
-                        cell.textContent = '~$' + xdai + ' xDAI';
-                        cell.style.fontSize = '0.8rem';
-                        cell.title = 'CoinGecko DAI/EUR unavailable \u2014 showing xDAI equivalent\n'
+                        label.textContent = '~$' + xdai + ' xDAI';
+                        label.style.fontSize = '0.8rem';
+                        bubble.textContent = 'CoinGecko DAI/EUR unavailable \u2014 showing xDAI equivalent\n'
                             + '1 CRC = $' + price.dcrc_xdai.toFixed(6) + ' xDAI\n'
                             + 'Rate date: ' + rateDate + '\n'
                             + 'Source: ' + sourceLabel;
                     } else {
-                        cell.textContent = '\u2014';
-                        cell.title = 'Price data unavailable for ' + txDate;
+                        label.textContent = '\u2014';
+                        bubble.textContent = 'Price data unavailable for ' + txDate;
                     }
                 }).catch(function(err) {
                     console.warn('EUR conversion failed for ' + txDate, err);
-                    cell.textContent = '\u2014';
-                    cell.title = 'Price conversion error';
+                    label.textContent = '\u2014';
+                    bubble.textContent = 'Price conversion error';
                 });
-            })(eurCell, r[3], r[5]);
+            })(eurLabel, eurBubble, eurCell, r[3], r[5]);
 
             // Reference (decoded from hex)
             var ref = hexToUtf8(r[4]);


### PR DESCRIPTION
## Summary

Follow-up to PR #40 — completes the legal audit requirements for EUR pricing in Marketplace Explorer:

- **Rate timestamp on every row**: tooltip shows `Rate date: YYYY-MM-DD` confirming which day's rate was used
- **Source provenance**: tooltip shows `Balancer V3 live`, `Balancer V3 historic`, or `cached` + CoinGecko DAI/EUR
- **Info icon on EUR column header**: explains daily granularity (UTC), Balancer V3 + CoinGecko source, xDAI fallback
- **EUR Volume card**: now shows source attribution line (`Balancer + CoinGecko, daily rate`) and flags partial xDAI fallback with `~` prefix
- **Explicit unavailable state**: `—` with tooltip `Price data unavailable for YYYY-MM-DD` when API returns no data

### API & accuracy notes

- **Pricing API**: `GET /metrics-api/pricing?date=YYYY-MM-DD` on metrics-exporter (staging only)
- **CRC/xDAI rate**: Balancer V3 SOR API — mid-price from sCRC/xDAI pool, demurrage-adjusted
- **xDAI/EUR rate**: CoinGecko DAI/EUR historical (DAI ≈ xDAI 1:1 proxy)
- **Granularity**: Daily (one rate per calendar day UTC) — standard for invoice purposes
- **Fallback chain**: PG cache → Balancer live/historic → CoinGecko → xDAI-only → unavailable
- **Caveat**: No pricing data before 2026-04-17 (when Balancer pool was created). Dates before that show `—`.

### Previous PRs in this feature set

| Repo | PR |
|------|-----|
| circles-nethermind-plugin | #341 (Balancer V3 pricing + `/pricing` API) |
| aboutcircles-infrastructure | #363 (env vars + Caddy route) |
| aboutcircles-infrastructure | #365 (CORS + rate limit fix) |
| CirclesTools | #40 (initial EUR column + URL fixes) |

## Test plan

- [ ] Open [marketplaceExplorer payments tab](https://aboutcircles.github.io/CirclesTools/marketplaceExplorer.html?tab=payments&payee=0x3cf62e563c47d0f049c3ee56cc4955ebc2207984) 
- [ ] Hover EUR values — tooltip shows rate, date, source
- [ ] Check EUR Volume card shows source subtitle
- [ ] Hover `ⓘ` icon next to "EUR Value" header — shows granularity explanation
- [ ] Verify `—` shown for dates before 2026-04-17 with appropriate tooltip