### PR TITLE
fix: use staging RPC endpoint

### DIFF
--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1409,8 +1409,8 @@
     const SERVERS = {
         staging: {
             name: 'Staging',
-            rpc: 'https://staging.aboutcircles.com/',
-            pathfinder: 'https://staging.aboutcircles.com/',
+            rpc: 'https://rpc.staging.aboutcircles.com/',
+            pathfinder: 'https://rpc.staging.aboutcircles.com/',
             chainRpc: 'https://rpc.gnosischain.com'
         },
         prod: {


### PR DESCRIPTION
## Summary
- point the rpc query view staging server at `https://rpc.staging.aboutcircles.com/`
- update the pathfinder RPC target to the same staging RPC host

## Tests
- `curl` verified `https://rpc.staging.aboutcircles.com/` serves `circles_tables`
- `git diff --check`
- `node --check <(sed -n '/<script>/,/<\\/script>/p' rpcQueryView.html | sed '1d;$d')`