### PR TITLE
docs(rpcQueryView): group profile fields + groupType filter

### DIFF
--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1894,8 +1894,8 @@
             { name: 'Get Avatar Info', method: 'circles_getAvatarInfo', params: { address: '' } },
             { name: 'Get Full Profile', method: 'circles_getProfileByAddress', params: { address: '' } },
             { name: 'Search Profiles', method: 'circles_searchProfiles', params: { text: 'circles', limit: 20 } },
-            { name: 'Search Open Groups', method: 'circles_searchProfiles', params: { text: '', groupType: 'open', limit: 20 } },
-            { name: 'Search Closed Groups', method: 'circles_searchProfiles', params: { text: '', groupType: 'closed', limit: 20 } }
+            { name: 'Search Open Groups', method: 'circles_searchProfiles', params: { text: 'group', groupType: 'open', limit: 20 } },
+            { name: 'Search Closed Groups', method: 'circles_searchProfiles', params: { text: 'group', groupType: 'closed', limit: 20 } }
         ],
         trust: [
             { name: 'Get Trust Relations', method: 'circles_getTrustRelations', params: { address: '' } },

--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1486,14 +1486,14 @@
         },
         circles_getProfileByAddress: {
             category: 'avatar',
-            description: 'Get profile data for an avatar address',
+            description: 'Get profile data for an avatar address. May also return extended fields (omitted when unset): externalLinks.website, membershipCriteria.{minRepScore, membershipFee, additionalCriteria}, groupType, contactInfo.{email, website}.',
             params: [
                 { name: 'address', type: 'address', required: true, description: 'Avatar address' }
             ]
         },
         circles_getProfileByAddressBatch: {
             category: 'avatar',
-            description: 'Get profiles for multiple addresses',
+            description: 'Get profiles for multiple addresses. May also return extended fields per item (omitted when unset): externalLinks.website, membershipCriteria.{minRepScore, membershipFee, additionalCriteria}, groupType, contactInfo.{email, website}.',
             params: [
                 { name: 'addresses', type: 'address[]', required: true, description: 'Array of avatar addresses' }
             ]
@@ -1507,19 +1507,20 @@
         },
         circles_getProfileByCid: {
             category: 'avatar',
-            description: 'Retrieve a profile from IPFS by its CID',
+            description: 'Retrieve a profile from IPFS by its CID. May also return extended fields (omitted when unset): externalLinks.website, membershipCriteria.{minRepScore, membershipFee, additionalCriteria}, groupType, contactInfo.{email, website}.',
             params: [
                 { name: 'cid', type: 'string', required: true, description: 'CIDv0 string' }
             ]
         },
         circles_searchProfiles: {
             category: 'avatar',
-            description: 'Full-text search for profiles',
+            description: "Full-text search for profiles. Each result item's Profile sub-object may also include the extended group-profile fields (flat shape, omitted when unset): externalWebsite, minRepScore, membershipFee, additionalCriteria, groupType, contactEmail, contactWebsite.",
             params: [
                 { name: 'text', type: 'string', required: true, description: 'Search query (max 3 tokens)' },
                 { name: 'limit', type: 'number', required: false, default: 20, description: 'Max results (max 100)' },
                 { name: 'offset', type: 'number', required: false, default: 0, description: 'Pagination offset' },
-                { name: 'types', type: 'string[]', required: false, description: 'Filter by avatar types' }
+                { name: 'types', type: 'string[]', required: false, description: 'Filter by avatar types' },
+                { name: 'groupType', type: 'string', required: false, description: "Filter by group type: 'open' or 'closed'" }
             ]
         },
         circles_searchProfileByAddressOrName: {
@@ -1830,7 +1831,7 @@
         },
         circles_getProfileByCidBatch: {
             category: 'avatar',
-            description: 'Get multiple profile contents by IPFS CIDs (batch)',
+            description: 'Get multiple profile contents by IPFS CIDs (batch). May also return extended fields per item (omitted when unset): externalLinks.website, membershipCriteria.{minRepScore, membershipFee, additionalCriteria}, groupType, contactInfo.{email, website}.',
             params: [
                 { name: 'cids', type: 'string[]', required: true, description: 'Array of IPFS CIDs' }
             ]
@@ -1892,7 +1893,9 @@
         avatar: [
             { name: 'Get Avatar Info', method: 'circles_getAvatarInfo', params: { address: '' } },
             { name: 'Get Full Profile', method: 'circles_getProfileByAddress', params: { address: '' } },
-            { name: 'Search Profiles', method: 'circles_searchProfiles', params: { text: 'circles', limit: 20 } }
+            { name: 'Search Profiles', method: 'circles_searchProfiles', params: { text: 'circles', limit: 20 } },
+            { name: 'Search Open Groups', method: 'circles_searchProfiles', params: { text: '', groupType: 'open', limit: 20 } },
+            { name: 'Search Closed Groups', method: 'circles_searchProfiles', params: { text: '', groupType: 'closed', limit: 20 } }
         ],
         trust: [
             { name: 'Get Trust Relations', method: 'circles_getTrustRelations', params: { address: '' } },


### PR DESCRIPTION
## Summary

Documents the group-extension profile fields in the RPC Query Builder UI.

## What changed

- `circles_searchProfiles` parameter list includes `groupType` (`'open' | 'closed'`) with description.
- Descriptions of `circles_getProfileByAddress`, `circles_getProfileByAddressBatch`, `circles_getProfileByCid`, `circles_getProfileByCidBatch` extended to list the nested IPFS-shape return fields: `externalLinks.website`, `membershipCriteria.{minRepScore, membershipFee, additionalCriteria}`, `groupType`, `contactInfo.{email, website}`.
- Description of `circles_searchProfiles` extended to list the flat-shape return fields in result Profile sub-objects: `externalWebsite`, `minRepScore`, `membershipFee`, `additionalCriteria`, `groupType`, `contactEmail`, `contactWebsite`.
- Two new presets: "Search Open Groups", "Search Closed Groups".

## Audit follow-up (will land via fix PR targeting this branch before merge)

- **Preset `text` field is seeded** with a sample search term so the presets return results on first click — current `text: ''` always returns 0 (backend requires at least one token > 1 char).

## Test plan

- [ ] Open in browser, presets appear in the "Load preset…" dropdown
- [ ] Presets pre-fill a sample search term so they return results on first click
