### PR TITLE
fix(rpcQueryView): seed group-search presets with non-empty text

### DIFF
--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1894,8 +1894,8 @@
             { name: 'Get Avatar Info', method: 'circles_getAvatarInfo', params: { address: '' } },
             { name: 'Get Full Profile', method: 'circles_getProfileByAddress', params: { address: '' } },
             { name: 'Search Profiles', method: 'circles_searchProfiles', params: { text: 'circles', limit: 20 } },
-            { name: 'Search Open Groups', method: 'circles_searchProfiles', params: { text: '', groupType: 'open', limit: 20 } },
-            { name: 'Search Closed Groups', method: 'circles_searchProfiles', params: { text: '', groupType: 'closed', limit: 20 } }
+            { name: 'Search Open Groups', method: 'circles_searchProfiles', params: { text: 'group', groupType: 'open', limit: 20 } },
+            { name: 'Search Closed Groups', method: 'circles_searchProfiles', params: { text: 'group', groupType: 'closed', limit: 20 } }
         ],
         trust: [
             { name: 'Get Trust Relations', method: 'circles_getTrustRelations', params: { address: '' } },


### PR DESCRIPTION
## Summary

Audit follow-up for the group profile extension on the RPC Query Builder UI. Targets `feature/profile-group-fields` so the fix lands inside the feature branch before it merges to `main`.

## What changed

**Seed the group-search presets with a working starter text**
The "Search Open Groups" / "Search Closed Groups" presets shipped with `text: ''`. The backend's full-text search requires at least one token of length > 1, so the presets always returned 0 results on first click — confusing UX.

Seeded both presets with `text: 'group'`. Users can refine from a working query rather than starting from a dead one.

## Test plan

- [ ] Open the page in a browser.
- [ ] Click "Search Open Groups" preset → search executes and returns matching open groups against the configured RPC endpoint.
- [ ] Click "Search Closed Groups" preset → search executes and returns matching closed groups.
- [ ] Empty-text search still returns the expected `Invalid params` error if a user clears the preset and submits.
