### PR TITLE
refactor(rpcQueryView): rename affiliate-group methods to community

### DIFF
--- a/rpcQueryView.html
+++ b/rpcQueryView.html
@@ -1584,46 +1584,41 @@
                 { name: 'cursor', type: 'string', required: false, description: 'Pagination cursor' }
             ]
         },
-        circles_getAffiliateGroupWishlist: {
+        circles_getAvatarCommunitiesWishlist: {
             category: 'trust',
-            description: 'Multi-affiliate communities: the groups an avatar has signalled on-chain intent to join (the wishlist), each with its membershipFee (percent of daily gCRC mint, or null), plus the summed totalFeePercentage.',
-            serverNote: 'Only available on Staging',
+            description: 'Communities: the groups an avatar has signalled on-chain intent to join (the wishlist), each with its membershipFee (percent of daily gCRC mint, or null), plus the summed totalFeePercentage.',
             params: [
                 { name: 'avatar', type: 'address', required: true, description: 'Avatar address' }
             ]
         },
-        circles_getAffiliateGroups: {
+        circles_getAvatarCommunities: {
             category: 'trust',
-            description: 'Confirmed-membership subset of an avatar\'s affiliate wishlist: only groups that currently trust the avatar on-chain (the bilateral handshake; reflects TMS delay). totalFeePercentage is summed over this subset.',
-            serverNote: 'Only available on Staging',
+            description: 'Confirmed-membership subset of an avatar\'s community wishlist: only groups that currently trust the avatar on-chain (the bilateral handshake; reflects TMS delay). totalFeePercentage is summed over this subset.',
             params: [
                 { name: 'avatar', type: 'address', required: true, description: 'Avatar address' }
             ]
         },
-        circles_getAffiliateGroupFeesPercentage: {
+        circles_getAvatarCommunityFeesPercentage: {
             category: 'trust',
-            description: 'An avatar\'s total committed membership-fee percentage across its affiliate wishlist. Used to block joins that would exceed the 100% cap.',
-            serverNote: 'Only available on Staging',
+            description: 'An avatar\'s total committed membership-fee percentage across its community wishlist. Used to block joins that would exceed the 100% cap.',
             params: [
                 { name: 'avatar', type: 'address', required: true, description: 'Avatar address' }
             ]
         },
-        circles_getAffiliateGroupMembersWishlist: {
+        circles_getCommunityMembersWishlist: {
             category: 'trust',
-            description: 'Multi-affiliate communities: the avatars that have signalled intent to join a group (the group\'s members wishlist). Paginated. This is the set the TMS reconciles trust against.',
-            serverNote: 'Only available on Staging',
+            description: 'Communities: the avatars that have signalled intent to join a community (the community\'s members wishlist). Paginated. This is the set the TMS reconciles trust against.',
             params: [
-                { name: 'groupAddress', type: 'address', required: true, description: 'Group address' },
+                { name: 'communityAddress', type: 'address', required: true, description: 'Community address' },
                 { name: 'limit', type: 'number', required: false, default: 100, description: 'Max results (1-1000)' },
                 { name: 'cursor', type: 'string', required: false, description: 'Pagination cursor' }
             ]
         },
-        circles_getAffiliateGroupMembers: {
+        circles_getCommunityMembers: {
             category: 'trust',
-            description: 'Confirmed-membership subset of a group\'s affiliate wishlist: only avatars the group actually trusts on-chain (reflects TMS delay). Paginated.',
-            serverNote: 'Only available on Staging',
+            description: 'Confirmed-membership subset of a community\'s wishlist: only avatars the community actually trusts on-chain (reflects TMS delay). Paginated.',
             params: [
-                { name: 'groupAddress', type: 'address', required: true, description: 'Group address' },
+                { name: 'communityAddress', type: 'address', required: true, description: 'Community address' },
                 { name: 'limit', type: 'number', required: false, default: 100, description: 'Max results (1-1000)' },
                 { name: 'cursor', type: 'string', required: false, description: 'Pagination cursor' }
             ]


### PR DESCRIPTION
Renames the 5 multi-affiliate-group RPC methods in the RPC Query Builder to the community vocabulary, matching the plugin rename, and removes the "Only available on Staging" badge from them (they are being promoted to production).

- `circles_getAffiliateGroupWishlist` → `circles_getAvatarCommunitiesWishlist`
- `circles_getAffiliateGroups` → `circles_getAvatarCommunities`
- `circles_getAffiliateGroupFeesPercentage` → `circles_getAvatarCommunityFeesPercentage`
- `circles_getAffiliateGroupMembersWishlist` → `circles_getCommunityMembersWishlist` (param `groupAddress`→`communityAddress`)
- `circles_getAffiliateGroupMembers` → `circles_getCommunityMembers` (param `groupAddress`→`communityAddress`)

The raw `circles_query` example presets against the literal DB objects (`CrcV2_AffiliateGroupChanged`, `V_CrcV2_AffiliateMembersCount_*`) are unchanged — those DB names did not change. `circles_findGroups` keeps its own staging badge.

## Test plan
- [x] inline script passes `node --check`